### PR TITLE
handles empty string in addition to None

### DIFF
--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -206,7 +206,7 @@ class SNSBackend(BaseBackend):
             return candidate_topic
 
     def _get_values_nexttoken(self, values_map, next_token=None):
-        if next_token is None:
+        if next_token is None or not next_token:
             next_token = 0
         next_token = int(next_token)
         values = list(values_map.values())[


### PR DESCRIPTION
I hope I'm going about this the right way...

This is related to localstack issue [#1279](https://github.com/localstack/localstack/issues/1279) which I just opened.

Apologies, but this is actually the first python I've ever written so this may be completely wrong and I didn't feel ambitious to write a test just yet.  The gist is the .net sdk sends empty string on the first list topics request during certain operations (mentioned in issue [#1279](https://github.com/localstack/localstack/issues/1279)) and this is failing here as empty string is not None and cannot be parsed as int.