### PR TITLE
fixed precondition check for etags in s3

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1217,7 +1217,7 @@ class ResponseObject(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
             if_unmodified_since = str_to_rfc_1123_datetime(if_unmodified_since)
             if key.last_modified > if_unmodified_since:
                 raise PreconditionFailed("If-Unmodified-Since")
-        if if_match and key.etag != if_match:
+        if if_match and key.etag != '"{0}"'.format(if_match):
             raise PreconditionFailed("If-Match")
 
         if if_modified_since:


### PR DESCRIPTION
**Fixed**
- In the above precondition check - The value for `if_match`  was <etag> instead of "<etag>" (quotes were missing) which was leading code to execute unwanted conditions

**Terraform test**
- TestAccAWSS3BucketObject_metadata