### PR TITLE
fix s3 encryption response

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1217,7 +1217,7 @@ class ResponseObject(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
             if_unmodified_since = str_to_rfc_1123_datetime(if_unmodified_since)
             if key.last_modified > if_unmodified_since:
                 raise PreconditionFailed("If-Unmodified-Since")
-        if if_match and key.etag != '"{0}"'.format(if_match):
+        if if_match and key.etag not in [if_match, '"{0}"'.format(if_match)]:
             raise PreconditionFailed("If-Match")
 
         if if_modified_since:
@@ -2389,7 +2389,7 @@ S3_ENCRYPTION_CONFIG = """<?xml version="1.0" encoding="UTF-8"?>
                 <KMSMasterKeyID>{{ entry["Rule"]["ApplyServerSideEncryptionByDefault"]["KMSMasterKeyID"] }}</KMSMasterKeyID>
                 {% endif %}
             </ApplyServerSideEncryptionByDefault>
-            <BucketKeyEnabled>{{ 'true' if entry["Rule"].get("BucketKeyEnabled") else 'false' }}</BucketKeyEnabled>
+            <BucketKeyEnabled>{{ 'true' if entry["Rule"].get("BucketKeyEnabled") == 'true' else 'false' }}</BucketKeyEnabled>
         </Rule>
     {% endfor %}
 </ServerSideEncryptionConfiguration>


### PR DESCRIPTION
**Fixed**
- Fixed S3 encryption response `BucketKeyEnabled` was always returning `true`

**Reproducible Code**
```
resource "aws_s3_bucket" "arbitrary" {
  bucket = "test-1603981"

  server_side_encryption_configuration {
    rule {
      apply_server_side_encryption_by_default {
        sse_algorithm = "aws:kms"
      }
    }
  }
}
```