### PR TITLE
fix(events): Empty string instead of `null` in EventPattern

### DIFF
--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -596,7 +596,9 @@ class EventPattern:
             raise InvalidEventPatternException
 
     def __str__(self):
-        return json.dumps(self._filter)
+        if self._filter:
+            return json.dumps(self._filter)
+        return str()
 
     def _load_event_pattern(self, pattern):
         try:

--- a/tests/test_events/test_event_pattern.py
+++ b/tests/test_events/test_event_pattern.py
@@ -88,3 +88,14 @@ def test_event_pattern_with_multi_numeric_event_filter():
     assert two_or_three.matches_event(events[2])
     assert two_or_three.matches_event(events[3])
     assert not two_or_three.matches_event(events[4])
+
+
+@pytest.mark.parametrize(
+    "pattern, expected_str", [
+        ('{"source": ["foo", "bar"]}', '{"source": ["foo", "bar"]}'),
+        (None, ""),
+    ]
+)
+def test_event_pattern_str(pattern, expected_str):
+    event_pattern = EventPattern(pattern)
+    assert str(event_pattern) == expected_str


### PR DESCRIPTION
## Work done
Change `__str__` to avoid `None` when call string upon the class. This avoids `null` in the json response and makes [TestAccAWSCloudWatchEventArchive_basic](https://github.com/hashicorp/terraform-provider-aws/blob/72e623415ce30dfa463aa0cac7d3ef433b262824/aws/resource_aws_cloudwatch_event_archive_test.go#L74) pass

![image](https://user-images.githubusercontent.com/32211561/125659053-ef04b5c9-5d7e-43c0-a338-5fa5e7fc4e03.png)
