### PR TITLE
feat(logs): Add `kmsKeyId` into `LogGroup` entity.

### DIFF
--- a/moto/logs/models.py
+++ b/moto/logs/models.py
@@ -262,6 +262,11 @@ class LogGroup(BaseModel):
         )  # AWS defaults to Never Expire for log group retention
         self.subscription_filters = []
 
+        # The Amazon Resource Name (ARN) of the CMK to use when encrypting log data. It is optional.
+        # Docs:
+        # https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_CreateLogGroup.html
+        self.kms_key_id = kwargs.get("kmsKeyId")
+
     def create_log_stream(self, log_stream_name):
         if log_stream_name in self.streams:
             raise ResourceAlreadyExistsException()
@@ -442,6 +447,8 @@ class LogGroup(BaseModel):
         # AWS only returns retentionInDays if a value is set for the log group (ie. not Never Expire)
         if self.retention_in_days:
             log_group["retentionInDays"] = self.retention_in_days
+        if self.kms_key_id:
+            log_group["kmsKeyId"] = self.kms_key_id
         return log_group
 
     def set_retention_policy(self, retention_in_days):

--- a/moto/logs/responses.py
+++ b/moto/logs/responses.py
@@ -25,9 +25,10 @@ class LogsResponse(BaseResponse):
     def create_log_group(self):
         log_group_name = self._get_param("logGroupName")
         tags = self._get_param("tags")
+        kms_key_id = self._get_param("kmsKeyId")
         assert 1 <= len(log_group_name) <= 512  # TODO: assert pattern
 
-        self.logs_backend.create_log_group(log_group_name, tags)
+        self.logs_backend.create_log_group(log_group_name, tags, kmsKeyId=kms_key_id)
         return ""
 
     def delete_log_group(self):

--- a/tests/test_logs/test_logs.py
+++ b/tests/test_logs/test_logs.py
@@ -1,11 +1,12 @@
 import os
 import time
 from unittest import SkipTest
+
 import boto3
-import six
-from botocore.exceptions import ClientError
 import pytest
+import six
 import sure  # noqa
+from botocore.exceptions import ClientError
 
 from moto import mock_logs, settings
 
@@ -13,14 +14,32 @@ _logs_region = "us-east-1" if settings.TEST_SERVER_MODE else "us-west-2"
 
 
 @mock_logs
-def test_create_log_group():
+@pytest.mark.parametrize("kms_key_id", [
+    "arn:aws:kms:us-east-1:000000000000:key/51d81fab-b138-4bd2-8a09-07fd6d37224d",
+    None,
+
+])
+def test_create_log_group(kms_key_id):
+    # Given
     conn = boto3.client("logs", "us-west-2")
 
-    response = conn.create_log_group(logGroupName="dummy")
+    create_logs_params = dict(logGroupName="dummy")
+    if kms_key_id:
+        create_logs_params["kmsKeyId"] = kms_key_id
+
+    # When
+    response = conn.create_log_group(**create_logs_params)
     response = conn.describe_log_groups()
 
+    # Then
     response["logGroups"].should.have.length_of(1)
-    response["logGroups"][0].should_not.have.key("retentionInDays")
+
+    log_group = response["logGroups"][0]
+    log_group.should_not.have.key("retentionInDays")
+
+    if kms_key_id:
+        log_group.should.have.key("kmsKeyId")
+        log_group["kmsKeyId"].should.equal(kms_key_id)
 
 
 @mock_logs
@@ -511,7 +530,7 @@ def test_describe_subscription_filters_errors():
 
     # when
     with pytest.raises(ClientError) as e:
-        client.describe_subscription_filters(logGroupName="not-existing-log-group",)
+        client.describe_subscription_filters(logGroupName="not-existing-log-group", )
 
     # then
     ex = e.value

--- a/tests/test_logs/test_models.py
+++ b/tests/test_logs/test_models.py
@@ -1,0 +1,28 @@
+import sure  # noqa
+
+from moto.logs.models import LogGroup
+
+
+def test_log_group_to_describe_dict():
+    # Given
+    region = "us-east-1"
+    name = "test-log-group"
+    tags = {"TestTag": "TestValue"}
+    kms_key_id = "arn:aws:kms:us-east-1:000000000000:key/51d81fab-b138-4bd2-8a09-07fd6d37224d"
+    kwargs = dict(
+        kmsKeyId=kms_key_id,
+    )
+
+    # When
+    log_group = LogGroup(region, name, tags, **kwargs)
+    describe_dict = log_group.to_describe_dict()
+
+    # Then
+    expected_dict = dict(
+        logGroupName=name,
+        kmsKeyId=kms_key_id
+    )
+
+    for attr, value in expected_dict.items():
+        describe_dict.should.have.key(attr)
+        describe_dict[attr].should.equal(value)


### PR DESCRIPTION
## Work done
This PR adds the `kms_key_id` attribute in `LogGroup` and also ads the mentioned attribute in the describe response, as suggested on the AWS official API spec. 

It also parses the `kmsKeyId` from the `logs/CreateLogGroup` request. 

Docs: 
- https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_CreateLogGroup.html
- https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeLogGroups.html

This change makes the `TestAccAWSCloudwatchLogGroupDataSource_kms` pass. 
![image](https://user-images.githubusercontent.com/32211561/125716279-00de86df-e624-4231-a4b3-cabb4f4c3753.png)

Something to notice is that the whole `TestAccAWSCloudwatchLogGroupDataSource` suite is passing now! 

![image](https://user-images.githubusercontent.com/32211561/125716418-4c7ae09a-0752-4c8d-b518-a769629c6c55.png)

