### PR TITLE
feat(events): Add describe and delete connection

### DIFF
--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -544,7 +544,7 @@ class Replay(BaseModel):
 
 class Connection(BaseModel):
     def __init__(
-        self, name, region_name, description, authorization_type, auth_parameters,
+            self, name, region_name, description, authorization_type, auth_parameters,
     ):
         self.uuid = uuid4()
         self.name = name
@@ -582,7 +582,6 @@ class Connection(BaseModel):
             "ConnectionArn": self.arn,
             "ConnectionState": self.state,
             "CreationTime": self.creation_time,
-            "CreationTime": self.creation_time,
         }
 
     def describe(self):
@@ -613,7 +612,6 @@ class Connection(BaseModel):
             "Description": self.description,
             "Name": self.name,
         }
-
 
 
 class Destination(BaseModel):

--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -561,6 +561,60 @@ class Connection(BaseModel):
             self.region, ACCOUNT_ID, self.name, self.uuid
         )
 
+    def describe_short(self):
+        """
+        Create the short description for the Connection object.
+
+        Taken our from the Response Syntax of this API doc:
+            - https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_DeleteConnection.html
+
+        Something to consider:
+            - The original response also has
+                - LastAuthorizedTime (number)
+                - LastModifiedTime (number)
+            - At the time of implemeting this, there was no place where to set/get
+            those attributes. That is why they are not in the response.
+
+        Returns:
+            dict
+        """
+        return {
+            "ConnectionArn": self.arn,
+            "ConnectionState": self.state,
+            "CreationTime": self.creation_time,
+            "CreationTime": self.creation_time,
+        }
+
+    def describe(self):
+        """
+        Create a complete description for the Connection object.
+
+        Taken our from the Response Syntax of this API doc:
+            - https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_DescribeConnection.html
+
+        Something to consider:
+            - The original response also has:
+                - LastAuthorizedTime (number)
+                - LastModifiedTime (number)
+                - SecretArn (string)
+                - StateReason (string)
+            - At the time of implemeting this, there was no place where to set/get
+            those attributes. That is why they are not in the response.
+
+        Returns:
+            dict
+        """
+        return {
+            "AuthorizationType": self.authorization_type,
+            "AuthParameters": self.auth_parameters,
+            "ConnectionArn": self.arn,
+            "ConnectionState": self.state,
+            "CreationTime": self.creation_time,
+            "Description": self.description,
+            "Name": self.name,
+        }
+
+
 
 class Destination(BaseModel):
     def __init__(
@@ -1341,6 +1395,48 @@ class EventsBackend(BaseBackend):
 
     def list_connections(self):
         return self.connections.values()
+
+    def describe_connection(self, name):
+        """
+        Retrieves details about a connection.
+        Docs:
+            https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_DescribeConnection.html
+
+        Args:
+            name: The name of the connection to retrieve.
+
+        Raises:
+            ResourceNotFoundException: When the connection is not present.
+
+        Returns:
+            dict
+        """
+        connection = self.connections.get(name)
+        if not connection:
+            raise ResourceNotFoundException("Connection '{}' does not exist.".format(name))
+
+        return connection.describe()
+
+    def delete_connection(self, name):
+        """
+        Deletes a connection.
+        Docs:
+            https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_DeleteConnection.html
+
+        Args:
+            name: The name of the connection to delete.
+
+        Raises:
+            ResourceNotFoundException: When the connection is not present.
+
+        Returns:
+            dict
+        """
+        connection = self.connections.pop(name, None)
+        if not connection:
+            raise ResourceNotFoundException("Connection '{}' does not exist.".format(name))
+
+        return connection.describe_short()
 
     def create_api_destination(
         self, name, description, connection_arn, invocation_endpoint, http_method

--- a/moto/events/responses.py
+++ b/moto/events/responses.py
@@ -448,6 +448,16 @@ class EventsHandler(BaseResponse):
 
         return json.dumps({"Connections": result}), self.response_headers
 
+    def describe_connection(self):
+        name = self._get_param("Name")
+        result = self.events_backend.describe_connection(name)
+        return json.dumps(result), self.response_headers
+
+    def delete_connection(self):
+        name = self._get_param("Name")
+        result = self.events_backend.delete_connection(name)
+        return json.dumps(result), self.response_headers
+
     def create_api_destination(self):
         name = self._get_param("Name")
         description = self._get_param("Description")


### PR DESCRIPTION
## Work done
This PR adds the `describe_connection` and `delete_connection` to the events Response and Backend. 

Docs: 
- https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_DeleteConnection.html
- https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_DescribeConnection.html

This change makes the `TestAccAWSDataSourceCloudwatch_Event_Connection_basic` pass. 

![image](https://user-images.githubusercontent.com/32211561/126022021-3d1bd61b-426b-4d08-9d10-01811962a942.png)
