### PR TITLE
added support for transit gateway route tables

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -5997,11 +5997,13 @@ class TransitGatewayRouteTable(TaggedEC2Resource):
 
     def __init__(
         self,
+        backend,
         transit_gateway_id,
         tags=[],
         default_association_route_table=False,
         default_propagation_route_table=False,
     ):
+        self.ec2_backend = backend
         self.id = random_transit_gateway_route_table_id()
         self.transit_gateway_id = transit_gateway_id
 
@@ -6011,6 +6013,10 @@ class TransitGatewayRouteTable(TaggedEC2Resource):
         self.default_propagation_route_table = default_propagation_route_table
         self.state = "available"
         self.add_tags(tags or {})
+
+    @property
+    def physical_resource_id(self):
+        return self.id
 
     @property
     def create_time(self):
@@ -6030,6 +6036,7 @@ class TransitGatewayRouteTableBackend(object):
         default_propagation_route_table=False
     ):
         transit_gateways_route_table = TransitGatewayRouteTable(
+            self,
             transit_gateway_id=transit_gateway_id,
             tags=tags,
             default_association_route_table=default_association_route_table,

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -5988,6 +5988,7 @@ class TransitGatewayBackend(object):
 
 
 class TransitGatewayRouteTable(TaggedEC2Resource):
+
     def __init__(
         self,
         transit_gateway_id,
@@ -6030,6 +6031,47 @@ class TransitGatewayRouteTableBackend(object):
         )
         self.transit_gateways_route_table[transit_gateways_route_table.id] = transit_gateways_route_table
         return transit_gateways_route_table
+
+    def get_all_transit_gateway_route_tables(self, filters):
+        transit_gateway_route_tables = self.transit_gateways_route_table.values()
+
+        if filters is not None:
+            if filters.get("default-association-route-table") is not None:
+                transit_gateway_route_tables = [
+                    transit_gateway_route_table
+                    for transit_gateway_route_table in transit_gateway_route_tables
+                    if transit_gateway_route_table.default_association_route_table in filters["default-association-route-table"]
+                ]
+
+            if filters.get("default-propagation-route-table") is not None:
+                transit_gateway_route_tables = [
+                    transit_gateway_route_table
+                    for transit_gateway_route_table in transit_gateway_route_tables
+                    if transit_gateway_route_table.default_propagation_route_table in filters["default-propagation-route-table"]
+                ]
+
+            if filters.get("state") is not None:
+                transit_gateway_route_tables = [
+                    transit_gateway_route_table
+                    for transit_gateway_route_table in transit_gateway_route_tables
+                    if transit_gateway_route_table.state in filters["state"]
+                ]
+
+            if filters.get("transit-gateway-id") is not None:
+                transit_gateway_route_tables = [
+                    transit_gateway_route_table
+                    for transit_gateway_route_table in transit_gateway_route_tables
+                    if transit_gateway_route_table.transit_gateway_id in filters["transit-gateway-id"]
+                ]
+
+            if filters.get("transit-gateway-route-table-id") is not None:
+                transit_gateway_route_tables = [
+                    transit_gateway_route_table
+                    for transit_gateway_route_table in transit_gateway_route_tables
+                    if transit_gateway_route_table.id in filters["transit-gateway-route-table-id"]
+                ]
+
+        return transit_gateway_route_tables
 
 
 class NatGateway(CloudFormationModel):

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -125,6 +125,7 @@ from .utils import (
     random_internet_gateway_id,
     random_ip,
     random_ipv6_cidr,
+    random_transit_gateway_route_table_id,
     randor_ipv4_cidr,
     random_launch_template_id,
     random_nat_gateway_id,
@@ -5986,6 +5987,51 @@ class TransitGatewayBackend(object):
         return transit_gateway
 
 
+class TransitGatewayRouteTable(TaggedEC2Resource):
+    def __init__(
+        self,
+        transit_gateway_id,
+        tags=[],
+        default_association_route_table=False,
+        default_propagation_route_table=False,
+    ):
+        self.id = random_transit_gateway_route_table_id()
+        self.transit_gateway_id = transit_gateway_id
+
+        self._created_at = datetime.utcnow()
+
+        self.default_association_route_table = default_association_route_table
+        self.default_propagation_route_table = default_propagation_route_table
+        self.state = "available"
+        self.add_tags(tags or {})
+
+    @property
+    def create_time(self):
+        return iso_8601_datetime_with_milliseconds(self._created_at)
+
+
+class TransitGatewayRouteTableBackend(object):
+    def __init__(self):
+        self.transit_gateways_route_table = {}
+        super(TransitGatewayRouteTableBackend, self).__init__()
+
+    def create_transit_gateway_route_table(
+        self,
+        transit_gateway_id,
+        tags=[],
+        default_association_route_table=False,
+        default_propagation_route_table=False
+    ):
+        transit_gateways_route_table = TransitGatewayRouteTable(
+            transit_gateway_id=transit_gateway_id,
+            tags=tags,
+            default_association_route_table=default_association_route_table,
+            default_propagation_route_table=default_propagation_route_table
+        )
+        self.transit_gateways_route_table[transit_gateways_route_table.id] = transit_gateways_route_table
+        return transit_gateways_route_table
+
+
 class NatGateway(CloudFormationModel):
     def __init__(self, backend, subnet_id, allocation_id, tags=[]):
         # public properties
@@ -6346,6 +6392,7 @@ class EC2Backend(
     CustomerGatewayBackend,
     NatGatewayBackend,
     TransitGatewayBackend,
+    TransitGatewayRouteTableBackend,
     LaunchTemplateBackend,
     IamInstanceProfileAssociationBackend,
 ):

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -6019,7 +6019,7 @@ class TransitGatewayRouteTable(TaggedEC2Resource):
 
 class TransitGatewayRouteTableBackend(object):
     def __init__(self):
-        self.transit_gateways_route_table = {}
+        self.transit_gateways_route_tables = {}
         super(TransitGatewayRouteTableBackend, self).__init__()
 
     def create_transit_gateway_route_table(
@@ -6035,11 +6035,11 @@ class TransitGatewayRouteTableBackend(object):
             default_association_route_table=default_association_route_table,
             default_propagation_route_table=default_propagation_route_table
         )
-        self.transit_gateways_route_table[transit_gateways_route_table.id] = transit_gateways_route_table
+        self.transit_gateways_route_tables[transit_gateways_route_table.id] = transit_gateways_route_table
         return transit_gateways_route_table
 
     def get_all_transit_gateway_route_tables(self, filters):
-        transit_gateway_route_tables = self.transit_gateways_route_table.values()
+        transit_gateway_route_tables = self.transit_gateways_route_tables.values()
 
         if filters is not None:
             if filters.get("default-association-route-table") is not None:
@@ -6078,6 +6078,9 @@ class TransitGatewayRouteTableBackend(object):
                 ]
 
         return transit_gateway_route_tables
+
+    def delete_transit_gateway_route_table(self, transit_gateway_route_table_id):
+        return self.transit_gateways_route_tables.pop(transit_gateway_route_table_id)
 
 
 class NatGateway(CloudFormationModel):

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -5972,6 +5972,12 @@ class TransitGatewayBackend(object):
                     for transit_gateway in transit_gateways
                     if transit_gateway.state in filters["state"]
                 ]
+            if filters.get("owner-id") is not None:
+                transit_gateways = [
+                    transit_gateway
+                    for transit_gateway in transit_gateways
+                    if transit_gateway.owner_id in filters["owner-id"]
+                ]
 
         return transit_gateways
 

--- a/moto/ec2/responses/__init__.py
+++ b/moto/ec2/responses/__init__.py
@@ -35,6 +35,7 @@ from .vpn_connections import VPNConnections
 from .windows import Windows
 from .nat_gateways import NatGateways
 from .transit_gateways import TransitGateways
+from .transit_gateway_route_tables import TransitGatewayRouteTable
 from .iam_instance_profiles import IamInstanceProfiles
 
 
@@ -74,6 +75,7 @@ class EC2Response(
     Windows,
     NatGateways,
     TransitGateways,
+    TransitGatewayRouteTable,
     IamInstanceProfiles,
 ):
     @property

--- a/moto/ec2/responses/transit_gateway_route_tables.py
+++ b/moto/ec2/responses/transit_gateway_route_tables.py
@@ -1,0 +1,31 @@
+from __future__ import unicode_literals
+from moto.core.responses import BaseResponse
+
+
+class TransitGatewayRouteTable(BaseResponse):
+    def create_transit_gateway_route_table(self):
+        transit_gateway_id = self._get_param("TransitGatewayId")
+        tags = self._get_multi_param("TagSpecification")
+        tags = tags[0] if isinstance(tags, list) and len(tags) == 1 else tags
+        tags = (tags or {}).get("Tag", [])
+        tags = {t["Key"]: t["Value"] for t in tags}
+
+        transit_gateway_route_table = self.ec2_backend.create_transit_gateway_route_table(
+            transit_gateway_id=transit_gateway_id, tags=tags
+        )
+        template = self.response_template(CREATE_TRANSIT_GATEWAY_ROUTE_TABLE_RESPONSE)
+        return template.render(transit_gateway_route_table=transit_gateway_route_table)
+
+
+CREATE_TRANSIT_GATEWAY_ROUTE_TABLE_RESPONSE = """<CreateTransitGatewayRouteTableResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+    <requestId>3a495d25-08d4-466d-822e-477c9b1fc606</requestId>
+    <transitGatewayRouteTable>
+        <creationTime>{{ transit_gateway_route_table._created_at }}</creationTime>
+        <defaultAssociationRouteTable>{{ transit_gateway_route_table.default_association_route_table }}</defaultAssociationRouteTable>
+        <defaultPropagationRouteTable>{{ transit_gateway_route_table.default_propagation_route_table }}</defaultPropagationRouteTable>
+        <state>{{ transit_gateway_route_table.state }}</state>
+        <transitGatewayId>{{ transit_gateway_route_table.transit_gateway_id }}</transitGatewayId>
+        <transitGatewayRouteTableId>{{ transit_gateway_route_table.id }}</transitGatewayRouteTableId>
+    </transitGatewayRouteTable>
+</CreateTransitGatewayRouteTableResponse>
+"""

--- a/moto/ec2/responses/transit_gateway_route_tables.py
+++ b/moto/ec2/responses/transit_gateway_route_tables.py
@@ -6,7 +6,7 @@ from moto.ec2.utils import filters_from_querystring
 class TransitGatewayRouteTable(BaseResponse):
     def create_transit_gateway_route_table(self):
         transit_gateway_id = self._get_param("TransitGatewayId")
-        tags = self._get_multi_param("TagSpecification")
+        tags = self._get_multi_param("TagSpecifications")
         tags = tags[0] if isinstance(tags, list) and len(tags) == 1 else tags
         tags = (tags or {}).get("Tag", [])
         tags = {t["Key"]: t["Value"] for t in tags}

--- a/moto/ec2/responses/transit_gateway_route_tables.py
+++ b/moto/ec2/responses/transit_gateway_route_tables.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 from moto.core.responses import BaseResponse
+from moto.ec2.utils import filters_from_querystring
 
 
 class TransitGatewayRouteTable(BaseResponse):
@@ -16,6 +17,12 @@ class TransitGatewayRouteTable(BaseResponse):
         template = self.response_template(CREATE_TRANSIT_GATEWAY_ROUTE_TABLE_RESPONSE)
         return template.render(transit_gateway_route_table=transit_gateway_route_table)
 
+    def describe_transit_gateway_route_tables(self):
+        filters = filters_from_querystring(self.querystring)
+        transit_gateway_route_tables = self.ec2_backend.get_all_transit_gateway_route_tables(filters)
+        template = self.response_template(DESCRIBE_TRANSIT_GATEWAY_ROUTE_TABLE_RESPONSE)
+        return template.render(transit_gateway_route_tables=transit_gateway_route_tables)
+
 
 CREATE_TRANSIT_GATEWAY_ROUTE_TABLE_RESPONSE = """<CreateTransitGatewayRouteTableResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>3a495d25-08d4-466d-822e-477c9b1fc606</requestId>
@@ -26,6 +33,39 @@ CREATE_TRANSIT_GATEWAY_ROUTE_TABLE_RESPONSE = """<CreateTransitGatewayRouteTable
         <state>{{ transit_gateway_route_table.state }}</state>
         <transitGatewayId>{{ transit_gateway_route_table.transit_gateway_id }}</transitGatewayId>
         <transitGatewayRouteTableId>{{ transit_gateway_route_table.id }}</transitGatewayRouteTableId>
+        <tagSet>
+            {% for tag in transit_gateway.get_tags() %}
+                <item>
+                    <key>{{ tag.key }}</key>
+                    <value>{{ tag.value }}</value>
+                </item>
+            {% endfor %}
+        </tagSet>
     </transitGatewayRouteTable>
 </CreateTransitGatewayRouteTableResponse>
+"""
+
+DESCRIBE_TRANSIT_GATEWAY_ROUTE_TABLE_RESPONSE = """<DescribeTransitGatewayRouteTablesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+    <requestId>f9dea58a-7bb3-458b-a40d-0b7ae32eefdb</requestId>
+    <transitGatewayRouteTables>
+        {% for transit_gateway_route_table in transit_gateway_route_tables %}
+        <item>
+            <creationTime>{{ transit_gateway_route_table._created_at }}</creationTime>
+            <defaultAssociationRouteTable>{{ transit_gateway_route_table.default_association_route_table }}</defaultAssociationRouteTable>
+            <defaultPropagationRouteTable>{{ transit_gateway_route_table.default_propagation_route_table }}</defaultPropagationRouteTable>
+            <state>{{ transit_gateway_route_table.state }}</state>
+            <tagSet>
+                {% for tag in transit_gateway.get_tags() %}
+                    <item>
+                        <key>{{ tag.key }}</key>
+                        <value>{{ tag.value }}</value>
+                    </item>
+                {% endfor %}
+            </tagSet>
+            <transitGatewayId>{{ transit_gateway_route_table.transit_gateway_id }}</transitGatewayId>
+            <transitGatewayRouteTableId>{{ transit_gateway_route_table.id }}</transitGatewayRouteTableId>
+        </item>
+        {% endfor %}
+    </transitGatewayRouteTables>
+</DescribeTransitGatewayRouteTablesResponse>
 """

--- a/moto/ec2/responses/transit_gateway_route_tables.py
+++ b/moto/ec2/responses/transit_gateway_route_tables.py
@@ -33,14 +33,14 @@ class TransitGatewayRouteTable(BaseResponse):
 CREATE_TRANSIT_GATEWAY_ROUTE_TABLE_RESPONSE = """<CreateTransitGatewayRouteTableResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>3a495d25-08d4-466d-822e-477c9b1fc606</requestId>
     <transitGatewayRouteTable>
-        <creationTime>{{ transit_gateway_route_table._created_at }}</creationTime>
+        <creationTime>{{ transit_gateway_route_table.create_time }}</creationTime>
         <defaultAssociationRouteTable>{{ transit_gateway_route_table.default_association_route_table }}</defaultAssociationRouteTable>
         <defaultPropagationRouteTable>{{ transit_gateway_route_table.default_propagation_route_table }}</defaultPropagationRouteTable>
         <state>{{ transit_gateway_route_table.state }}</state>
         <transitGatewayId>{{ transit_gateway_route_table.transit_gateway_id }}</transitGatewayId>
         <transitGatewayRouteTableId>{{ transit_gateway_route_table.id }}</transitGatewayRouteTableId>
         <tagSet>
-            {% for tag in transit_gateway.get_tags() %}
+            {% for tag in transit_gateway_route_table.get_tags() %}
                 <item>
                     <key>{{ tag.key }}</key>
                     <value>{{ tag.value }}</value>
@@ -56,12 +56,12 @@ DESCRIBE_TRANSIT_GATEWAY_ROUTE_TABLE_RESPONSE = """<DescribeTransitGatewayRouteT
     <transitGatewayRouteTables>
         {% for transit_gateway_route_table in transit_gateway_route_tables %}
         <item>
-            <creationTime>{{ transit_gateway_route_table._created_at }}</creationTime>
+            <creationTime>{{ transit_gateway_route_table.create_time }}</creationTime>
             <defaultAssociationRouteTable>{{ transit_gateway_route_table.default_association_route_table }}</defaultAssociationRouteTable>
             <defaultPropagationRouteTable>{{ transit_gateway_route_table.default_propagation_route_table }}</defaultPropagationRouteTable>
             <state>{{ transit_gateway_route_table.state }}</state>
             <tagSet>
-                {% for tag in transit_gateway.get_tags() %}
+                {% for tag in transit_gateway_route_table.get_tags() %}
                     <item>
                         <key>{{ tag.key }}</key>
                         <value>{{ tag.value }}</value>
@@ -81,7 +81,7 @@ DELETE_TRANSIT_GATEWAY_ROUTE_TABLE_RESPONSE = """<DeleteTransitGatewayRouteTable
     <transitGatewayRouteTable>
         {% for transit_gateway_route_table in transit_gateway_route_tables %}
         <item>
-            <creationTime>{{ transit_gateway_route_table._created_at }}</creationTime>
+            <creationTime>{{ transit_gateway_route_table.create_time }}</creationTime>
             <defaultAssociationRouteTable>{{ transit_gateway_route_table.default_association_route_table }}</defaultAssociationRouteTable>
             <defaultPropagationRouteTable>{{ transit_gateway_route_table.default_propagation_route_table }}</defaultPropagationRouteTable>
             <state>{{ transit_gateway_route_table.state }}</state>

--- a/moto/ec2/responses/transit_gateway_route_tables.py
+++ b/moto/ec2/responses/transit_gateway_route_tables.py
@@ -23,6 +23,12 @@ class TransitGatewayRouteTable(BaseResponse):
         template = self.response_template(DESCRIBE_TRANSIT_GATEWAY_ROUTE_TABLE_RESPONSE)
         return template.render(transit_gateway_route_tables=transit_gateway_route_tables)
 
+    def delete_transit_gateway_route_table(self):
+        transit_gateway_route_table_id = self._get_param("TransitGatewayRouteTableId")
+        transit_gateway_route_table = self.ec2_backend.delete_transit_gateway_route_table(transit_gateway_route_table_id)
+        template = self.response_template(DELETE_TRANSIT_GATEWAY_ROUTE_TABLE_RESPONSE)
+        return template.render(transit_gateway_route_table=transit_gateway_route_table)
+
 
 CREATE_TRANSIT_GATEWAY_ROUTE_TABLE_RESPONSE = """<CreateTransitGatewayRouteTableResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>3a495d25-08d4-466d-822e-477c9b1fc606</requestId>
@@ -68,4 +74,21 @@ DESCRIBE_TRANSIT_GATEWAY_ROUTE_TABLE_RESPONSE = """<DescribeTransitGatewayRouteT
         {% endfor %}
     </transitGatewayRouteTables>
 </DescribeTransitGatewayRouteTablesResponse>
+"""
+
+DELETE_TRANSIT_GATEWAY_ROUTE_TABLE_RESPONSE = """<DeleteTransitGatewayRouteTableResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+    <requestId>a9a07226-c7b1-4305-9934-0bcfc3ef1c5e</requestId>
+    <transitGatewayRouteTable>
+        {% for transit_gateway_route_table in transit_gateway_route_tables %}
+        <item>
+            <creationTime>{{ transit_gateway_route_table._created_at }}</creationTime>
+            <defaultAssociationRouteTable>{{ transit_gateway_route_table.default_association_route_table }}</defaultAssociationRouteTable>
+            <defaultPropagationRouteTable>{{ transit_gateway_route_table.default_propagation_route_table }}</defaultPropagationRouteTable>
+            <state>{{ transit_gateway_route_table.state }}</state>
+            <transitGatewayId>{{ transit_gateway_route_table.transit_gateway_id }}</transitGatewayId>
+            <transitGatewayRouteTableId>{{ transit_gateway_route_table.id }}</transitGatewayRouteTableId>
+        </item>
+        {% endfor %}
+    </transitGatewayRouteTable>
+</DeleteTransitGatewayRouteTableResponse>
 """

--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -17,6 +17,7 @@ from moto.iam import iam_backends
 EC2_RESOURCE_TO_PREFIX = {
     "customer-gateway": "cgw",
     "transit-gateway": "tgw",
+    "transit-gateway-route-table": "tgw-rtb",
     "dhcp-options": "dopt",
     "flow-logs": "fl",
     "image": "ami",
@@ -172,6 +173,10 @@ def random_nat_gateway_id():
 
 def random_transit_gateway_id():
     return random_id(prefix=EC2_RESOURCE_TO_PREFIX["transit-gateway"], size=17)
+
+
+def random_transit_gateway_route_table_id():
+    return random_id(prefix=EC2_RESOURCE_TO_PREFIX["transit-gateway-route-table"], size=17)
 
 
 def random_launch_template_id():

--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -526,6 +526,9 @@ def random_key_pair():
 
 def get_prefix(resource_id):
     resource_id_prefix, separator, after = resource_id.partition("-")
+    if resource_id_prefix == EC2_RESOURCE_TO_PREFIX["transit-gateway"]:
+        if after.startswith("rtb"):
+            resource_id_prefix = EC2_RESOURCE_TO_PREFIX["transit-gateway-route-table"]
     if resource_id_prefix == EC2_RESOURCE_TO_PREFIX["network-interface"]:
         if after.startswith("attach"):
             resource_id_prefix = EC2_RESOURCE_TO_PREFIX["network-interface-attachment"]


### PR DESCRIPTION
**Added**
- API_CreateTransitGatewayRouteTable
- API_DescribeTransitGatewayRouteTable
- API_DeleteTransitGatewayRouteTable
- Expanded API_DescribeTransitGateway for extra filter support
- Updated `get_prefix(...)` to support `tgw-rtb`

**Tested with**
- Tested by applying multiple times, updating, destroying
```
resource "aws_ec2_transit_gateway" "example" {
  description                     = "test description"
  default_route_table_propagation = "disable"
  dns_support                     = "disable"
  tags = {
    "Name"     = "testTransitGateway",
    "testKey" = "testValueTansit"
  }
}


resource "aws_ec2_transit_gateway_route_table" "example" {
  transit_gateway_id = aws_ec2_transit_gateway.example.id
  tags = {
    "testKey" = "testValue"
  }
}
```