### PR TITLE
support for passing transit gateway route table id in describe api, minor refractoring

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -6045,8 +6045,15 @@ class TransitGatewayRouteTableBackend(object):
         self.transit_gateways_route_tables[transit_gateways_route_table.id] = transit_gateways_route_table
         return transit_gateways_route_table
 
-    def get_all_transit_gateway_route_tables(self, filters):
+    def get_all_transit_gateway_route_tables(self, transit_gateway_ids, filters):
         transit_gateway_route_tables = self.transit_gateways_route_tables.values()
+
+        if transit_gateway_ids is not None:
+            transit_gateway_route_tables = [
+                transit_gateway_route_table
+                for transit_gateway_route_table in transit_gateway_route_tables
+                if transit_gateway_route_table.id in transit_gateway_ids
+            ]
 
         if filters is not None:
             if filters.get("default-association-route-table") is not None:

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -6048,6 +6048,14 @@ class TransitGatewayRouteTableBackend(object):
     def get_all_transit_gateway_route_tables(self, transit_gateway_ids, filters):
         transit_gateway_route_tables = self.transit_gateways_route_tables.values()
 
+        attr_pairs = (
+            ("default-association-route-table", "default_association_route_table"),
+            ("default-propagation-route-table", "default_propagation_route_table"),
+            ("state", "state"),
+            ("transit-gateway-id", "transit_gateway_id"),
+            ("transit-gateway-route-table-id", "id")
+        )
+
         if transit_gateway_ids is not None:
             transit_gateway_route_tables = [
                 transit_gateway_route_table
@@ -6055,40 +6063,12 @@ class TransitGatewayRouteTableBackend(object):
                 if transit_gateway_route_table.id in transit_gateway_ids
             ]
 
-        if filters is not None:
-            if filters.get("default-association-route-table") is not None:
+        for attrs in attr_pairs:
+            values = filters.get(attrs[0]) or None
+            if values is not None:
                 transit_gateway_route_tables = [
-                    transit_gateway_route_table
-                    for transit_gateway_route_table in transit_gateway_route_tables
-                    if transit_gateway_route_table.default_association_route_table in filters["default-association-route-table"]
-                ]
-
-            if filters.get("default-propagation-route-table") is not None:
-                transit_gateway_route_tables = [
-                    transit_gateway_route_table
-                    for transit_gateway_route_table in transit_gateway_route_tables
-                    if transit_gateway_route_table.default_propagation_route_table in filters["default-propagation-route-table"]
-                ]
-
-            if filters.get("state") is not None:
-                transit_gateway_route_tables = [
-                    transit_gateway_route_table
-                    for transit_gateway_route_table in transit_gateway_route_tables
-                    if transit_gateway_route_table.state in filters["state"]
-                ]
-
-            if filters.get("transit-gateway-id") is not None:
-                transit_gateway_route_tables = [
-                    transit_gateway_route_table
-                    for transit_gateway_route_table in transit_gateway_route_tables
-                    if transit_gateway_route_table.transit_gateway_id in filters["transit-gateway-id"]
-                ]
-
-            if filters.get("transit-gateway-route-table-id") is not None:
-                transit_gateway_route_tables = [
-                    transit_gateway_route_table
-                    for transit_gateway_route_table in transit_gateway_route_tables
-                    if transit_gateway_route_table.id in filters["transit-gateway-route-table-id"]
+                    transit_gateway_route_table for transit_gateway_route_table in transit_gateway_route_tables
+                    if not values or getattr(transit_gateway_route_table, attrs[1]) in values
                 ]
 
         return transit_gateway_route_tables

--- a/moto/ec2/responses/transit_gateway_route_tables.py
+++ b/moto/ec2/responses/transit_gateway_route_tables.py
@@ -19,7 +19,8 @@ class TransitGatewayRouteTable(BaseResponse):
 
     def describe_transit_gateway_route_tables(self):
         filters = filters_from_querystring(self.querystring)
-        transit_gateway_route_tables = self.ec2_backend.get_all_transit_gateway_route_tables(filters)
+        transit_gateway_ids = self._get_multi_param("TransitGatewayRouteTableIds") or None
+        transit_gateway_route_tables = self.ec2_backend.get_all_transit_gateway_route_tables(transit_gateway_ids, filters)
         template = self.response_template(DESCRIBE_TRANSIT_GATEWAY_ROUTE_TABLE_RESPONSE)
         return template.render(transit_gateway_route_tables=transit_gateway_route_tables)
 


### PR DESCRIPTION
**Follow Up PR**
#27 

**Added**
- Support for passing transit gateway route table id in describe api

**TF Test Fix**
- TestAccAWSEc2TransitGatewayRouteTableDataSource_ID