### PR TITLE
Added support for TGW-VPN-attachment

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -5427,7 +5427,7 @@ class DHCPOptionsSetBackend(object):
 
 
 class VPNConnection(TaggedEC2Resource):
-    def __init__(self, ec2_backend, id, type, customer_gateway_id, vpn_gateway_id):
+    def __init__(self, ec2_backend, id, type, customer_gateway_id, vpn_gateway_id=None, transit_gateway_id=None, tags=None):
         self.ec2_backend = ec2_backend
         self.id = id
         self.state = "available"
@@ -5435,9 +5435,11 @@ class VPNConnection(TaggedEC2Resource):
         self.type = type
         self.customer_gateway_id = customer_gateway_id
         self.vpn_gateway_id = vpn_gateway_id
+        self.transit_gateway_id = transit_gateway_id
         self.tunnels = None
         self.options = None
         self.static_routes = None
+        self.add_tags(tags or {})
 
     def get_filter_value(self, filter_name):
         return super(VPNConnection, self).get_filter_value(
@@ -5451,7 +5453,7 @@ class VPNConnectionBackend(object):
         super(VPNConnectionBackend, self).__init__()
 
     def create_vpn_connection(
-        self, type, customer_gateway_id, vpn_gateway_id, static_routes_only=None
+        self, type, customer_gateway_id, vpn_gateway_id=None, transit_gateway_id=None, static_routes_only=None, tags=None
     ):
         vpn_connection_id = random_vpn_connection_id()
         if static_routes_only:
@@ -5462,6 +5464,8 @@ class VPNConnectionBackend(object):
             type=type,
             customer_gateway_id=customer_gateway_id,
             vpn_gateway_id=vpn_gateway_id,
+            transit_gateway_id=transit_gateway_id,
+            tags=tags
         )
         self.vpn_connections[vpn_connection.id] = vpn_connection
         return vpn_connection
@@ -5469,10 +5473,10 @@ class VPNConnectionBackend(object):
     def delete_vpn_connection(self, vpn_connection_id):
 
         if vpn_connection_id in self.vpn_connections:
-            self.vpn_connections.pop(vpn_connection_id)
+            self.vpn_connections[vpn_connection_id].state = "deleted"
         else:
             raise InvalidVpnConnectionIdError(vpn_connection_id)
-        return True
+        return self.vpn_connections[vpn_connection_id]
 
     def describe_vpn_connections(self, vpn_connection_ids=None):
         vpn_connections = []
@@ -6216,6 +6220,11 @@ class TransitGatewayAttachmentBackend(object):
         self.transit_gateways_attachments = {}
         super(TransitGatewayAttachmentBackend, self).__init__()
 
+    def create_transit_gateway_vpn_attachment(self, vpn_id, transit_gateway_id, tags=[]):
+        transit_gateway_vpn_attachment = TransitGatewayAttachment(self, resource_id=vpn_id, resource_type="vpn", transit_gateway_id=transit_gateway_id, tags=tags)
+        self.transit_gateways_attachments[transit_gateway_vpn_attachment.id] = transit_gateway_vpn_attachment
+        return transit_gateway_vpn_attachment
+
     def create_transit_gateway_vpc_attachment(
         self,
         transit_gateway_id,
@@ -6232,7 +6241,62 @@ class TransitGatewayAttachmentBackend(object):
             subnet_ids=subnet_ids,
             options=options
         )
+        self.transit_gateways_attachments[transit_gateway_vpc_attachment.id] = transit_gateway_vpc_attachment
         return transit_gateway_vpc_attachment
+
+    def describe_transit_gateway_attachments(self, transit_gateways_attachment_ids=None, filters=None, max_results=0):
+        transit_gateways_attachments = self.transit_gateways_attachments.values()
+
+        attr_pairs = (
+            ("resource-id", "resource_id"),
+            ("resource-type", "resource_type"),
+            ("transit-gateway-id", "transit_gateway_id")
+        )
+
+        if not transit_gateways_attachment_ids == [] and transit_gateways_attachment_ids is not None:
+            transit_gateways_attachments = [
+                transit_gateways_attachment
+                for transit_gateways_attachment in transit_gateways_attachments
+                if transit_gateways_attachment.id in transit_gateways_attachment_ids
+            ]
+
+        if filters:
+            for attrs in attr_pairs:
+                values = filters.get(attrs[0]) or None
+                if values is not None:
+                    transit_gateways_attachments = [
+                        transit_gateways_attachment for transit_gateways_attachment in transit_gateways_attachments
+                        if getattr(transit_gateways_attachment, attrs[1]) in values
+                    ]
+        return transit_gateways_attachments
+    
+    def describe_transit_gateway_vpc_attachments(self, transit_gateways_attachment_ids=None, filters=None, max_results=0):
+        transit_gateways_attachments = self.transit_gateways_attachments.values()
+
+        attr_pairs = (
+            ("state", "state"),
+            ("transit-gateway-attachment-id", "id"),
+            ("transit-gateway-id", "transit_gateway_id"),
+            ("vpc-id", "resource_id")
+        )
+
+        if not transit_gateways_attachment_ids == [] and transit_gateways_attachment_ids is not None:
+            transit_gateways_attachments = [
+                transit_gateways_attachment
+                for transit_gateways_attachment in transit_gateways_attachments
+                if transit_gateways_attachment.id in transit_gateways_attachment_ids
+            ]
+
+        if filters:
+            for attrs in attr_pairs:
+                values = filters.get(attrs[0]) or None
+                if values is not None:
+                    transit_gateways_attachments = [
+                        transit_gateways_attachment for transit_gateways_attachment in transit_gateways_attachments
+                        if getattr(transit_gateways_attachment, attrs[1]) in values
+                    ]
+
+        return transit_gateways_attachments
 
 
 class NatGateway(CloudFormationModel):

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -6256,7 +6256,7 @@ class TransitGatewayAttachmentBackend(object):
             ("transit-gateway-id", "transit_gateway_id")
         )
 
-        if not transit_gateways_attachment_ids == [] and transit_gateways_attachment_ids is not None:
+        if transit_gateways_attachment_ids:
             transit_gateways_attachments = [
                 transit_gateways_attachment
                 for transit_gateways_attachment in transit_gateways_attachments

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -5819,8 +5819,10 @@ class VpnGatewayBackend(object):
         return attachment
 
     def delete_vpn_gateway(self, vpn_gateway_id):
-        self.vpn_gateways[vpn_gateway_id].state = "deleted"
-        return self.vpn_gateways[vpn_gateway_id]
+        deleted = self.vpn_gateways.pop(vpn_gateway_id, None)
+        if not deleted:
+            raise InvalidVpnGatewayIdError(vpn_gateway_id)
+        return deleted
 
     def detach_vpn_gateway(self, vpn_gateway_id, vpc_id):
         vpn_gateway = self.get_vpn_gateway(vpn_gateway_id)

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -6269,7 +6269,7 @@ class TransitGatewayAttachmentBackend(object):
                         if getattr(transit_gateways_attachment, attrs[1]) in values
                     ]
         return transit_gateways_attachments
-    
+
     def describe_transit_gateway_vpc_attachments(self, transit_gateways_attachment_ids=None, filters=None, max_results=0):
         transit_gateways_attachments = self.transit_gateways_attachments.values()
 

--- a/moto/ec2/responses/transit_gateway_attachments.py
+++ b/moto/ec2/responses/transit_gateway_attachments.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 from moto.core.responses import BaseResponse
+from moto.ec2.utils import filters_from_querystring
 
 
 class TransitGatewayAttachment(BaseResponse):
@@ -23,6 +24,30 @@ class TransitGatewayAttachment(BaseResponse):
         )
         template = self.response_template(CREATE_TRANSIT_GATEWAY_VPC_ATTACHMENT)
         return template.render(transit_gateway_attachment=transit_gateway_attachment)
+
+    def describe_transit_gateway_vpc_attachments(self):
+        transit_gateways_attachment_ids = self._get_multi_param("TransitGatewayAttachmentIds")
+        filters = filters_from_querystring(self.querystring)
+        max_results = self._get_param("MaxResults")
+        transit_gateway_vpc_attachments = self.ec2_backend.describe_transit_gateway_vpc_attachments(
+            transit_gateways_attachment_ids=transit_gateways_attachment_ids,
+            filters=filters,
+            max_results=max_results
+        )
+        template = self.response_template(DESCRIBE_TRANSIT_GATEWAY_VPC_ATTACHMENTS)
+        return template.render(transit_gateway_vpc_attachments=transit_gateway_vpc_attachments)
+
+    def describe_transit_gateway_attachments(self):
+        transit_gateways_attachment_ids = self._get_multi_param("TransitGatewayAttachmentIds")
+        filters = filters_from_querystring(self.querystring)
+        max_results = self._get_param("MaxResults")
+        transit_gateway_attachments = self.ec2_backend.describe_transit_gateway_attachments(
+            transit_gateways_attachment_ids=transit_gateways_attachment_ids,
+            filters=filters,
+            max_results=max_results
+        )
+        template = self.response_template(DESCRIBE_TRANSIT_GATEWAY_ATTACHMENTS)
+        return template.render(transit_gateway_attachments=transit_gateway_attachments)
 
 
 CREATE_TRANSIT_GATEWAY_VPC_ATTACHMENT = """<CreateTransitGatewayVpcAttachmentResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
@@ -54,3 +79,71 @@ CREATE_TRANSIT_GATEWAY_VPC_ATTACHMENT = """<CreateTransitGatewayVpcAttachmentRes
             <vpcOwnerId>{{ transit_gateway_attachment.resource_owner_id }}</vpcOwnerId>
     </transitGatewayVpcAttachment>
 </CreateTransitGatewayVpcAttachmentResponse>"""
+
+
+DESCRIBE_TRANSIT_GATEWAY_ATTACHMENTS = """<DescribeTransitGatewayAttachmentsResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+    <requestId>92aa7885-74c0-42d1-a846-e59bd07488a7</requestId>
+    <transitGatewayAttachments>
+        {% for transit_gateway_attachment in transit_gateway_attachments %}
+        <item>
+            <association>
+                <state>associated</state>
+                <transitGatewayRouteTableId>tgw-rtb-0b36edb9b88f0d5e3</transitGatewayRouteTableId>
+            </association>
+            <creationTime>2021-07-18T08:57:21.000Z</creationTime>
+            <resourceId>{{ transit_gateway_attachment.resource_id }}</resourceId>
+            <resourceOwnerId>{{ transit_gateway_attachment.resource_owner_id }}</resourceOwnerId>
+            <resourceType>{{ transit_gateway_attachment.resource_type }}</resourceType>
+            <state>{{ transit_gateway_attachment.state }}</state>
+            <tagSet>
+            {% for tag in transit_gateway_attachment.get_tags() %}
+                <item>
+                    <key>{{ tag.key }}</key>
+                    <value>{{ tag.value }}</value>
+                </item>
+            {% endfor %}
+            </tagSet>
+            <transitGatewayAttachmentId>{{ transit_gateway_attachment.id }}</transitGatewayAttachmentId>
+            <transitGatewayId>{{ transit_gateway_attachment.transit_gateway_id }}</transitGatewayId>
+            <transitGatewayOwnerId>074255357339</transitGatewayOwnerId>
+        </item>
+        {% endfor %}
+    </transitGatewayAttachments>
+</DescribeTransitGatewayAttachmentsResponse>
+"""
+
+
+DESCRIBE_TRANSIT_GATEWAY_VPC_ATTACHMENTS = """<DescribeTransitGatewayVpcAttachmentsResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+        <requestId>bebc9670-0205-4f28-ad89-049c97e46633</requestId>
+        <transitGatewayVpcAttachments>
+        {% for transit_gateway_vpc_attachment in transit_gateway_vpc_attachments %}
+            <item>
+                <creationTime>2021-07-18T08:57:21.000Z</creationTime>
+                <options>
+                    <applianceModeSupport>{{ transit_gateway_vpc_attachment.options.ApplianceModeSupport }}</applianceModeSupport>
+                    <dnsSupport>{{ transit_gateway_vpc_attachment.options.DnsSupport }}</dnsSupport>
+                    <ipv6Support>{{ transit_gateway_vpc_attachment.options.Ipv6Support }}</ipv6Support>
+                </options>
+                <state>{{ transit_gateway_vpc_attachment.state }}</state>
+                <subnetIds>
+                {% for id in transit_gateway_vpc_attachment.subnet_ids %}
+                    <item>id</item>
+                {% endfor %}
+                </subnetIds>
+                <tagSet>
+                {% for tag in transit_gateway_vpc_attachment.get_tags() %}
+                    <item>
+                        <key>{{ tag.key }}</key>
+                        <value>{{ tag.value }}</value>
+                    </item>
+                {% endfor %}
+                </tagSet>
+                <transitGatewayAttachmentId>{{ transit_gateway_vpc_attachment.id }}</transitGatewayAttachmentId>
+                <transitGatewayId>{{ transit_gateway_vpc_attachment.transit_gateway_id }}</transitGatewayId>
+                <vpcId>{{ transit_gateway_vpc_attachment.vpc_id }}</vpcId>
+                <vpcOwnerId>074255357339</vpcOwnerId>
+            </item>
+        {% endfor %}
+    </transitGatewayVpcAttachments>
+</DescribeTransitGatewayVpcAttachmentsResponse>
+"""

--- a/moto/ec2/responses/virtual_private_gateways.py
+++ b/moto/ec2/responses/virtual_private_gateways.py
@@ -13,7 +13,14 @@ class VirtualPrivateGateways(BaseResponse):
 
     def create_vpn_gateway(self):
         type = self._get_param("Type")
-        vpn_gateway = self.ec2_backend.create_vpn_gateway(type)
+        amazon_side_asn = self._get_param("AmazonSideAsn")
+        availability_zone = self._get_param("AvailabilityZone")
+        tags = self._get_multi_param("TagSpecification")
+        tags = tags[0] if isinstance(tags, list) and len(tags) == 1 else tags
+        tags = (tags or {}).get("Tag", [])
+        tags = {t["Key"]: t["Value"] for t in tags}
+        vpn_gateway = self.ec2_backend.create_vpn_gateway(
+            type=type, amazon_side_asn=amazon_side_asn, availability_zone=availability_zone, tags=tags)
         template = self.response_template(CREATE_VPN_GATEWAY_RESPONSE)
         return template.render(vpn_gateway=vpn_gateway)
 
@@ -44,7 +51,7 @@ CREATE_VPN_GATEWAY_RESPONSE = """
     <vpnGatewayId>{{ vpn_gateway.id }}</vpnGatewayId>
     <state>available</state>
     <type>{{ vpn_gateway.type }}</type>
-    <availabilityZone>us-east-1a</availabilityZone>
+    <availabilityZone>{{ vpn_gateway.availability_zone }}</availabilityZone>
     <attachments/>
     <tagSet>
       {% for tag in vpn_gateway.get_tags() %}

--- a/moto/ec2/responses/vpn_connections.py
+++ b/moto/ec2/responses/vpn_connections.py
@@ -170,8 +170,10 @@ CREATE_VPN_CONNECTION_RESPONSE = """
       </customerGatewayConfiguration>
     <type>ipsec.1</type>
     <customerGatewayId>{{ vpn_connection.customer_gateway_id }}</customerGatewayId>
-    <vpnGatewayId> {{ vpn_connection.vpn_gateway_id if vpn_connection.vpn_gateway_id is not none }} </vpnGatewayId>
-    <transitGatewayId>{{ vpn_connection.transit_gateway_id if vpn_connection.transit_gateway_id is not in none }}</transitGatewayId>
+    <vpnGatewayId> {{ vpn_connection.vpn_gateway_id or '' }} </vpnGatewayId>
+    {% if vpn_connection.transit_gateway_id %}
+    <transitGatewayId>{{ vpn_connection.transit_gateway_id }}</transitGatewayId>
+    {% endif %}
     <tagSet>
     {% for tag in vpn_connection.get_tags() %}
       <item>
@@ -216,8 +218,10 @@ DESCRIBE_VPN_CONNECTION_RESPONSE = """
       </customerGatewayConfiguration>
       <type>ipsec.1</type>
       <customerGatewayId>{{ vpn_connection.customer_gateway_id }}</customerGatewayId>
-      <vpnGatewayId> {{ vpn_connection.vpn_gateway_id if vpn_connection.vpn_gateway_id is not none }} </vpnGatewayId>
-      <transitGatewayId>{{ vpn_connection.transit_gateway_id if vpn_connection.transit_gateway_id is not none }}</transitGatewayId>
+      <vpnGatewayId> {{ vpn_connection.vpn_gateway_id or '' }} </vpnGatewayId>
+      {% if vpn_connection.transit_gateway_id %}
+      <transitGatewayId>{{ vpn_connection.transit_gateway_id }}</transitGatewayId>
+      {% endif %}
       <tagSet>
       {% for tag in vpn_connection.get_tags() %}
         <item>

--- a/moto/ec2/responses/vpn_connections.py
+++ b/moto/ec2/responses/vpn_connections.py
@@ -18,7 +18,8 @@ class VPNConnections(BaseResponse):
         vpn_connection = self.ec2_backend.create_vpn_connection(
             type, cgw_id, vpn_gateway_id=vgw_id, transit_gateway_id=tgw_id, static_routes_only=static_routes, tags=tags
         )
-        self.ec2_backend.create_transit_gateway_vpn_attachment(vpn_id=vpn_connection.id, transit_gateway_id=tgw_id)
+        if vpn_connection.transit_gateway_id:
+            self.ec2_backend.create_transit_gateway_vpn_attachment(vpn_id=vpn_connection.id, transit_gateway_id=tgw_id)
         template = self.response_template(CREATE_VPN_CONNECTION_RESPONSE)
         return template.render(vpn_connection=vpn_connection)
 
@@ -170,7 +171,7 @@ CREATE_VPN_CONNECTION_RESPONSE = """
     <type>ipsec.1</type>
     <customerGatewayId>{{ vpn_connection.customer_gateway_id }}</customerGatewayId>
     <vpnGatewayId> {{ vpn_connection.vpn_gateway_id if vpn_connection.vpn_gateway_id is not none }} </vpnGatewayId>
-    <transitGatewayId>{{ vpn_connection.transit_gateway_id if vpn_connection.transit_gateway_id is not none }}</transitGatewayId>
+    <transitGatewayId>{{ vpn_connection.transit_gateway_id if vpn_connection.transit_gateway_id is not in none }}</transitGatewayId>
     <tagSet>
     {% for tag in vpn_connection.get_tags() %}
       <item>

--- a/moto/ec2/responses/vpn_connections.py
+++ b/moto/ec2/responses/vpn_connections.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 from moto.core.responses import BaseResponse
 from moto.ec2.utils import filters_from_querystring
+from xml.sax.saxutils import escape
 
 
 class VPNConnections(BaseResponse):
@@ -8,16 +9,27 @@ class VPNConnections(BaseResponse):
         type = self._get_param("Type")
         cgw_id = self._get_param("CustomerGatewayId")
         vgw_id = self._get_param("VpnGatewayId")
+        tgw_id = self._get_param("TransitGatewayId")
         static_routes = self._get_param("StaticRoutesOnly")
+        tags = self._get_multi_param("TagSpecification")
+        tags = tags[0] if isinstance(tags, list) and len(tags) == 1 else tags
+        tags = (tags or {}).get("Tag", [])
+        tags = {t["Key"]: t["Value"] for t in tags}
         vpn_connection = self.ec2_backend.create_vpn_connection(
-            type, cgw_id, vgw_id, static_routes_only=static_routes
+            type, cgw_id, vpn_gateway_id=vgw_id, transit_gateway_id=tgw_id, static_routes_only=static_routes, tags=tags
         )
+        self.ec2_backend.create_transit_gateway_vpn_attachment(vpn_id=vpn_connection.id, transit_gateway_id=tgw_id)
         template = self.response_template(CREATE_VPN_CONNECTION_RESPONSE)
         return template.render(vpn_connection=vpn_connection)
 
     def delete_vpn_connection(self):
         vpn_connection_id = self._get_param("VpnConnectionId")
         vpn_connection = self.ec2_backend.delete_vpn_connection(vpn_connection_id)
+        if vpn_connection.transit_gateway_id:
+            transit_gateway_attachments = self.ec2_backend.describe_transit_gateway_attachments()
+            for attachment in transit_gateway_attachments:
+                if attachment.resource_id == vpn_connection.id:
+                    attachment.state = "deleted"
         template = self.response_template(DELETE_VPN_CONNECTION_RESPONSE)
         return template.render(vpn_connection=vpn_connection)
 
@@ -31,17 +43,11 @@ class VPNConnections(BaseResponse):
         return template.render(vpn_connections=vpn_connections)
 
 
-CREATE_VPN_CONNECTION_RESPONSE = """
-<CreateVpnConnectionResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
-  <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
-  <vpnConnection>
-    <vpnConnectionId>{{ vpn_connection.id }}</vpnConnectionId>
-    <state>pending</state>
-      <customerGatewayConfiguration>
-        <vpn_connection id="{{ vpn_connection.id }}">
+CUSTOMER_GATEWAY_CONFIGURATION_TEMPLATE = """
+          <vpn_connection id="{{ vpn_connection.id }}">
           <customer_gateway_id>{{ vpn_connection.customer_gateway_id }}</customer_gateway_id>
-          <vpn_gateway_id>{{ vpn_connection.vpn_gateway_id }}</vpn_gateway_id>
-          <vpn_connection_type>ipsec.1</vpn_connection_type>
+          <vpn_gateway_id> {{ vpn_connection.vpn_gateway_id if vpn_connection.vpn_gateway_id is not none }} </vpn_gateway_id>
+          <vpn_connection_type>{{ vpn_connection.type }}</vpn_connection_type>
           <ipsec_tunnel>
             <customer_gateway>
             <tunnel_outside_address>
@@ -149,15 +155,25 @@ CREATE_VPN_CONNECTION_RESPONSE = """
             </ipsec>
           </ipsec_tunnel>
         </vpn_connection>
+"""
+
+CREATE_VPN_CONNECTION_RESPONSE = """
+<CreateVpnConnectionResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+  <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
+  <vpnConnection>
+    <vpnConnectionId>{{ vpn_connection.id }}</vpnConnectionId>
+    <state>{{ vpn_connection.state }}</state>
+      <customerGatewayConfiguration>
+    """ + escape(CUSTOMER_GATEWAY_CONFIGURATION_TEMPLATE) + \
+    """
       </customerGatewayConfiguration>
     <type>ipsec.1</type>
     <customerGatewayId>{{ vpn_connection.customer_gateway_id }}</customerGatewayId>
-    <vpnGatewayId>{{ vpn_connection.vpn_gateway_id }}</vpnGatewayId>
+    <vpnGatewayId> {{ vpn_connection.vpn_gateway_id if vpn_connection.vpn_gateway_id is not none }} </vpnGatewayId>
+    <transitGatewayId>{{ vpn_connection.transit_gateway_id if vpn_connection.transit_gateway_id is not none }}</transitGatewayId>
     <tagSet>
     {% for tag in vpn_connection.get_tags() %}
       <item>
-        <resourceId>{{ tag.resource_id }}</resourceId>
-        <resourceType>{{ tag.resource_type }}</resourceType>
         <key>{{ tag.key }}</key>
         <value>{{ tag.value }}</value>
       </item>
@@ -165,6 +181,7 @@ CREATE_VPN_CONNECTION_RESPONSE = """
     </tagSet>
   </vpnConnection>
 </CreateVpnConnectionResponse>"""
+
 
 CREATE_VPN_CONNECTION_ROUTE_RESPONSE = """
 <CreateVpnConnectionRouteResponse xmlns="http://ec2.amazonaws.com/doc/2013-10- 15/">
@@ -191,128 +208,18 @@ DESCRIBE_VPN_CONNECTION_RESPONSE = """
     {% for vpn_connection in vpn_connections %}
     <item>
       <vpnConnectionId>{{ vpn_connection.id }}</vpnConnectionId>
-      <state>available</state>
+      <state>{{ vpn_connection.state }}</state>
       <customerGatewayConfiguration>
-        <vpn_connection id="{{ vpn_connection.id }}">
-          <customer_gateway_id>{{ vpn_connection.customer_gateway_id }}</customer_gateway_id>
-          <vpn_gateway_id>{{ vpn_connection.vpn_gateway_id }}</vpn_gateway_id>
-          <vpn_connection_type>ipsec.1</vpn_connection_type>
-          <ipsec_tunnel>
-            <customer_gateway>
-            <tunnel_outside_address>
-              <ip_address>12.1.2.3</ip_address>
-            </tunnel_outside_address>
-            <tunnel_inside_address>
-              <ip_address>169.254.44.42</ip_address>
-              <network_mask>255.255.255.252</network_mask>
-              <network_cidr>30</network_cidr>
-            </tunnel_inside_address>
-            <bgp>
-              <asn>65000</asn>
-              <hold_time>30</hold_time>
-            </bgp>
-            </customer_gateway>
-            <vpn_gateway>
-            <tunnel_outside_address>
-              <ip_address>52.2.144.13</ip_address>
-            </tunnel_outside_address>
-            <tunnel_inside_address>
-              <ip_address>169.254.44.41</ip_address>
-              <network_mask>255.255.255.252</network_mask>
-              <network_cidr>30</network_cidr>
-            </tunnel_inside_address>
-            <bgp>
-              <asn>7224</asn>
-              <hold_time>30</hold_time>
-            </bgp>
-            </vpn_gateway>
-            <ike>
-            <authentication_protocol>sha1</authentication_protocol>
-            <encryption_protocol>aes-128-cbc</encryption_protocol>
-            <lifetime>28800</lifetime>
-            <perfect_forward_secrecy>group2</perfect_forward_secrecy>
-            <mode>main</mode>
-            <pre_shared_key>Iw2IAN9XUsQeYUrkMGP3kP59ugFDkfHg</pre_shared_key>
-            </ike>
-            <ipsec>
-            <protocol>esp</protocol>
-            <authentication_protocol>hmac-sha1-96</authentication_protocol>
-            <encryption_protocol>aes-128-cbc</encryption_protocol>
-            <lifetime>3600</lifetime>
-            <perfect_forward_secrecy>group2</perfect_forward_secrecy>
-            <mode>tunnel</mode>
-            <clear_df_bit>true</clear_df_bit>
-            <fragmentation_before_encryption>true</fragmentation_before_encryption>
-            <tcp_mss_adjustment>1387</tcp_mss_adjustment>
-            <dead_peer_detection>
-              <interval>10</interval>
-              <retries>3</retries>
-            </dead_peer_detection>
-            </ipsec>
-          </ipsec_tunnel>
-          <ipsec_tunnel>
-            <customer_gateway>
-            <tunnel_outside_address>
-              <ip_address>12.1.2.3</ip_address>
-            </tunnel_outside_address>
-            <tunnel_inside_address>
-              <ip_address>169.254.44.42</ip_address>
-              <network_mask>255.255.255.252</network_mask>
-              <network_cidr>30</network_cidr>
-            </tunnel_inside_address>
-            <bgp>
-              <asn>65000</asn>
-              <hold_time>30</hold_time>
-            </bgp>
-            </customer_gateway>
-            <vpn_gateway>
-            <tunnel_outside_address>
-              <ip_address>52.2.144.13</ip_address>
-            </tunnel_outside_address>
-            <tunnel_inside_address>
-              <ip_address>169.254.44.41</ip_address>
-              <network_mask>255.255.255.252</network_mask>
-              <network_cidr>30</network_cidr>
-            </tunnel_inside_address>
-            <bgp>
-              <asn>7224</asn>
-              <hold_time>30</hold_time>
-            </bgp>
-            </vpn_gateway>
-            <ike>
-            <authentication_protocol>sha1</authentication_protocol>
-            <encryption_protocol>aes-128-cbc</encryption_protocol>
-            <lifetime>28800</lifetime>
-            <perfect_forward_secrecy>group2</perfect_forward_secrecy>
-            <mode>main</mode>
-            <pre_shared_key>Iw2IAN9XUsQeYUrkMGP3kP59ugFDkfHg</pre_shared_key>
-            </ike>
-            <ipsec>
-            <protocol>esp</protocol>
-            <authentication_protocol>hmac-sha1-96</authentication_protocol>
-            <encryption_protocol>aes-128-cbc</encryption_protocol>
-            <lifetime>3600</lifetime>
-            <perfect_forward_secrecy>group2</perfect_forward_secrecy>
-            <mode>tunnel</mode>
-            <clear_df_bit>true</clear_df_bit>
-            <fragmentation_before_encryption>true</fragmentation_before_encryption>
-            <tcp_mss_adjustment>1387</tcp_mss_adjustment>
-            <dead_peer_detection>
-              <interval>10</interval>
-              <retries>3</retries>
-            </dead_peer_detection>
-            </ipsec>
-          </ipsec_tunnel>
-        </vpn_connection>
+    """ + escape(CUSTOMER_GATEWAY_CONFIGURATION_TEMPLATE) + \
+    """
       </customerGatewayConfiguration>
       <type>ipsec.1</type>
       <customerGatewayId>{{ vpn_connection.customer_gateway_id }}</customerGatewayId>
-      <vpnGatewayId>{{ vpn_connection.vpn_gateway_id }}</vpnGatewayId>
+      <vpnGatewayId> {{ vpn_connection.vpn_gateway_id if vpn_connection.vpn_gateway_id is not none }} </vpnGatewayId>
+      <transitGatewayId>{{ vpn_connection.transit_gateway_id if vpn_connection.transit_gateway_id is not none }}</transitGatewayId>
       <tagSet>
       {% for tag in vpn_connection.get_tags() %}
         <item>
-          <resourceId>{{ tag.resource_id }}</resourceId>
-          <resourceType>{{ tag.resource_type }}</resourceType>
           <key>{{ tag.key }}</key>
           <value>{{ tag.value }}</value>
         </item>

--- a/moto/ec2/responses/vpn_connections.py
+++ b/moto/ec2/responses/vpn_connections.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from moto.core.responses import BaseResponse
-from moto.ec2.utils import filters_from_querystring
+from moto.ec2.utils import filters_from_querystring, add_tag_specification
 from xml.sax.saxutils import escape
 
 
@@ -11,10 +11,7 @@ class VPNConnections(BaseResponse):
         vgw_id = self._get_param("VpnGatewayId")
         tgw_id = self._get_param("TransitGatewayId")
         static_routes = self._get_param("StaticRoutesOnly")
-        tags = self._get_multi_param("TagSpecification")
-        tags = tags[0] if isinstance(tags, list) and len(tags) == 1 else tags
-        tags = (tags or {}).get("Tag", [])
-        tags = {t["Key"]: t["Value"] for t in tags}
+        tags = add_tag_specification(self._get_multi_param("TagSpecification"))
         vpn_connection = self.ec2_backend.create_vpn_connection(
             type, cgw_id, vpn_gateway_id=vgw_id, transit_gateway_id=tgw_id, static_routes_only=static_routes, tags=tags
         )
@@ -170,7 +167,7 @@ CREATE_VPN_CONNECTION_RESPONSE = """
       </customerGatewayConfiguration>
     <type>ipsec.1</type>
     <customerGatewayId>{{ vpn_connection.customer_gateway_id }}</customerGatewayId>
-    <vpnGatewayId> {{ vpn_connection.vpn_gateway_id or '' }} </vpnGatewayId>
+    <vpnGatewayId>{{ vpn_connection.vpn_gateway_id or '' }}</vpnGatewayId>
     {% if vpn_connection.transit_gateway_id %}
     <transitGatewayId>{{ vpn_connection.transit_gateway_id }}</transitGatewayId>
     {% endif %}
@@ -218,7 +215,7 @@ DESCRIBE_VPN_CONNECTION_RESPONSE = """
       </customerGatewayConfiguration>
       <type>ipsec.1</type>
       <customerGatewayId>{{ vpn_connection.customer_gateway_id }}</customerGatewayId>
-      <vpnGatewayId> {{ vpn_connection.vpn_gateway_id or '' }} </vpnGatewayId>
+      <vpnGatewayId>{{ vpn_connection.vpn_gateway_id or '' }}</vpnGatewayId>
       {% if vpn_connection.transit_gateway_id %}
       <transitGatewayId>{{ vpn_connection.transit_gateway_id }}</transitGatewayId>
       {% endif %}

--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -358,6 +358,13 @@ def get_obj_tag_values(obj):
     return tags
 
 
+def add_tag_specification(tags):
+    tags = tags[0] if isinstance(tags, list) and len(tags) == 1 else tags
+    tags = (tags or {}).get("Tag", [])
+    tags = {t["Key"]: t["Value"] for t in tags}
+    return tags
+
+
 def tag_filter_matches(obj, filter_name, filter_values):
     regex_filters = [re.compile(simple_aws_filter_to_re(f)) for f in filter_values]
     if filter_name == "tag-key":

--- a/tests/test_ec2/test_vpn_connections.py
+++ b/tests/test_ec2/test_vpn_connections.py
@@ -29,7 +29,7 @@ def test_delete_vpn_connections():
     list_of_vpn_connections.should.have.length_of(1)
     conn.delete_vpn_connection(vpn_connection.id)
     list_of_vpn_connections = conn.get_all_vpn_connections()
-    list_of_vpn_connections.should.have.length_of(0)
+    list_of_vpn_connections[0].state.should.equal("deleted")
 
 
 @mock_ec2_deprecated


### PR DESCRIPTION
## Fixed
- `TransitGatewayVpcAttachment` objects are not being stored in the backend.
- `TransitGateway` support in `VpnConnection`.
- XML response of `CreateVpnConnection` and `DescribeVpnConnection`.
- `DeleteVpnConnection` logic. State needed to be 'deeted' instead of deleting actual object. **TODO**: delete `VpnConnection` object in clean up process.
- Fixed 'VpnGateway'. Still couple of methods are remmaining.

## Added
- Support for TransitGatewayAttachment of `VpnConnection`. (Attachment will directly be made right after creating `VpnConnection`).
- API `DescribeTransitGatewayAttachments`.
- API `DescribeTransitGatewayVpcAtatchments`.
- method `create_transit_gateway_vpn_attachment()` to create `TransitGatewayVpnConnectionAttachment`.

## Tested Terraform
- VpnConnection
```terraform
resource "aws_ec2_transit_gateway" "example" {}

resource "aws_customer_gateway" "example" {
  bgp_asn    = 65000
  ip_address = "172.0.0.1"
  type       = "ipsec.1"
}

resource "aws_vpn_connection" "example" {
  customer_gateway_id = aws_customer_gateway.example.id
  transit_gateway_id  = aws_ec2_transit_gateway.example.id
  type                = aws_customer_gateway.example.type
  tags = {
    Name = "name_value"
    test = "test_value"
  }
}
```
