### PR TITLE
feat(events): Add describe, update & delete api destination

### DIFF
--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -1516,6 +1516,24 @@ class EventsBackend(BaseBackend):
             raise ResourceNotFoundException("An api-destination '{}' does not exist.".format(name))
         return destination.describe()
 
+    def update_api_destination(self, *, name, **kwargs):
+        """
+        Creates an API destination, which is an HTTP invocation endpoint configured as a target for events.
+        Docs:
+            https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_UpdateApiDestination.html
+
+        Returns:
+            dict
+        """
+        destination = self.destinations.get(name)
+        if not destination:
+            raise ResourceNotFoundException("An api-destination '{}' does not exist.".format(name))
+
+        for attr, value in kwargs.items():
+            if value is not None and hasattr(destination, attr):
+                setattr(destination, attr, value)
+        return destination.describe_short()
+
     def delete_api_destination(self, name):
         """
         Deletes the specified API destination.

--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -641,7 +641,7 @@ class Destination(BaseModel):
         return "arn:aws:events:{0}:{1}:api-destination/{2}/{3}".format(
             self.region, ACCOUNT_ID, self.name, self.uuid
         )
-    
+
     def describe(self):
         """
         Describes the Destination object as a dict
@@ -1536,6 +1536,7 @@ class EventsBackend(BaseBackend):
         if not destination:
             raise ResourceNotFoundException("An api-destination '{}' does not exist.".format(name))
         return {}
+
 
 events_backends = {}
 for region in Session().get_available_regions("events"):

--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -622,6 +622,7 @@ class Destination(BaseModel):
         description,
         connection_arn,
         invocation_endpoint,
+        invocation_rate_limit_per_second,
         http_method,
     ):
         self.uuid = uuid4()
@@ -630,6 +631,7 @@ class Destination(BaseModel):
         self.description = description
         self.connection_arn = connection_arn
         self.invocation_endpoint = invocation_endpoint
+        self.invocation_rate_limit_per_second = invocation_rate_limit_per_second
         self.creation_time = unix_time(datetime.utcnow())
         self.http_method = http_method
         self.state = "ACTIVE"
@@ -639,6 +641,41 @@ class Destination(BaseModel):
         return "arn:aws:events:{0}:{1}:api-destination/{2}/{3}".format(
             self.region, ACCOUNT_ID, self.name, self.uuid
         )
+    
+    def describe(self):
+        """
+        Describes the Destination object as a dict
+        Docs:
+            Response Syntax in
+            https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_DescribeApiDestination.html
+
+        Something to consider:
+            - The response also has [InvocationRateLimitPerSecond] which was not
+            available when implementing this method
+
+        Returns:
+            dict
+        """
+        return {
+            "ApiDestinationArn": self.arn,
+            "ApiDestinationState": self.state,
+            "ConnectionArn": self.connection_arn,
+            "CreationTime": self.creation_time,
+            "Description": self.description,
+            "HttpMethod": self.http_method,
+            "InvocationEndpoint": self.invocation_endpoint,
+            "InvocationRateLimitPerSecond": self.invocation_rate_limit_per_second,
+            "LastModifiedTime": self.creation_time,
+            "Name": self.name,
+        }
+
+    def describe_short(self):
+        return {
+            "ApiDestinationArn": self.arn,
+            "ApiDestinationState": self.state,
+            "CreationTime": self.creation_time,
+            "LastModifiedTime": self.creation_time,
+        }
 
 
 class EventPattern:
@@ -1437,27 +1474,68 @@ class EventsBackend(BaseBackend):
         return connection.describe_short()
 
     def create_api_destination(
-        self, name, description, connection_arn, invocation_endpoint, http_method
+            self, name, description, connection_arn, invocation_endpoint, invocation_rate_limit_per_second, http_method
     ):
+        """
+        Creates an API destination, which is an HTTP invocation endpoint configured as a target for events.
+        Docs:
+            https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_CreateApiDestination.html
 
+        Returns:
+            dict
+        """
         destination = Destination(
             name=name,
             region_name=self.region_name,
             description=description,
             connection_arn=connection_arn,
             invocation_endpoint=invocation_endpoint,
+            invocation_rate_limit_per_second=invocation_rate_limit_per_second,
             http_method=http_method,
         )
 
         self.destinations[name] = destination
-        return destination
+        return destination.describe_short()
 
     def list_api_destinations(self):
         return self.destinations.values()
 
     def describe_api_destination(self, name):
-        return self.destinations.get(name)
+        """
+        Retrieves details about an API destination.
+        Docs:
+            https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_DescribeApiDestination.html
+        Args:
+            name: The name of the API destination to retrieve.
 
+        Returns:
+            dict
+        """
+        destination = self.destinations.get(name)
+        if not destination:
+            raise ResourceNotFoundException("An api-destination '{}' does not exist.".format(name))
+        return destination.describe()
+
+    def delete_api_destination(self, name):
+        """
+        Deletes the specified API destination.
+        Docs:
+            https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_DeleteApiDestination.html
+
+        Args:
+            name: The name of the destination to delete.
+
+        Raises:
+            ResourceNotFoundException: When the destination is not present.
+
+        Returns:
+            dict
+
+        """
+        destination = self.destinations.pop(name, None)
+        if not destination:
+            raise ResourceNotFoundException("An api-destination '{}' does not exist.".format(name))
+        return {}
 
 events_backends = {}
 for region in Session().get_available_regions("events"):

--- a/moto/events/responses.py
+++ b/moto/events/responses.py
@@ -43,6 +43,17 @@ class EventsHandler(BaseResponse):
         return self.request_params.get(param, if_none)
 
     def _create_response(self, result):
+        """
+        Creates a proper response for the API.
+
+        It basically transforms a dict-like result from the backend
+        into a tuple (str, dict) properly formatted.
+        Args:
+            result (dict): result from backend
+
+        Returns:
+            (str, dict): dumped result and headers
+        """
         return json.dumps(result), self.headers
 
     def error(self, type_, message="", status=400):

--- a/moto/events/responses.py
+++ b/moto/events/responses.py
@@ -42,6 +42,9 @@ class EventsHandler(BaseResponse):
     def _get_param(self, param, if_none=None):
         return self.request_params.get(param, if_none)
 
+    def _create_response(self, result):
+        return json.dumps(result), self.headers
+
     def error(self, type_, message="", status=400):
         headers = self.response_headers
         headers["status"] = status
@@ -469,7 +472,7 @@ class EventsHandler(BaseResponse):
         result = self.events_backend.create_api_destination(
             name, description, connection_arn, invocation_endpoint, invocation_rate_limit_per_second, http_method
         )
-        return json.dumps(result), self.response_headers
+        return self._create_response(result)
 
     def list_api_destinations(self):
         destinations = self.events_backend.list_api_destinations()
@@ -493,9 +496,22 @@ class EventsHandler(BaseResponse):
     def describe_api_destination(self):
         name = self._get_param("Name")
         result = self.events_backend.describe_api_destination(name)
-        return json.dumps(result), self.response_headers
+        return self._create_response(result)
+
+    def update_api_destination(self):
+        updates = dict(
+            connection_arn=self._get_param("ConnectionArn"),
+            description=self._get_param("Description"),
+            http_method=self._get_param("HttpMethod"),
+            invocation_endpoint=self._get_param("InvocationEndpoint"),
+            invocation_rate_limit_per_second=self._get_param("InvocationRateLimitPerSecond"),
+            name=self._get_param("Name"),
+        )
+
+        result = self.events_backend.update_api_destination(**updates)
+        return self._create_response(result)
 
     def delete_api_destination(self):
         name = self._get_param("Name")
         result = self.events_backend.delete_api_destination(name)
-        return json.dumps(result), self.response_headers
+        return self._create_response(result)

--- a/moto/events/responses.py
+++ b/moto/events/responses.py
@@ -463,22 +463,13 @@ class EventsHandler(BaseResponse):
         description = self._get_param("Description")
         connection_arn = self._get_param("ConnectionArn")
         invocation_endpoint = self._get_param("InvocationEndpoint")
+        invocation_rate_limit_per_second = self._get_param("InvocationRateLimitPerSecond")
         http_method = self._get_param("HttpMethod")
 
-        destination = self.events_backend.create_api_destination(
-            name, description, connection_arn, invocation_endpoint, http_method
+        result = self.events_backend.create_api_destination(
+            name, description, connection_arn, invocation_endpoint, invocation_rate_limit_per_second, http_method
         )
-        return (
-            json.dumps(
-                {
-                    "ApiDestinationArn": destination.arn,
-                    "ApiDestinationState": "ACTIVE",
-                    "CreationTime": destination.creation_time,
-                    "LastModifiedTime": destination.creation_time,
-                }
-            ),
-            self.response_headers,
-        )
+        return json.dumps(result), self.response_headers
 
     def list_api_destinations(self):
         destinations = self.events_backend.list_api_destinations()
@@ -501,20 +492,10 @@ class EventsHandler(BaseResponse):
 
     def describe_api_destination(self):
         name = self._get_param("Name")
-        destination = self.events_backend.describe_api_destination(name)
+        result = self.events_backend.describe_api_destination(name)
+        return json.dumps(result), self.response_headers
 
-        return (
-            json.dumps(
-                {
-                    "ApiDestinationArn": destination.arn,
-                    "Name": destination.name,
-                    "ApiDestinationState": destination.state,
-                    "ConnectionArn": destination.connection_arn,
-                    "InvocationEndpoint": destination.invocation_endpoint,
-                    "HttpMethod": destination.http_method,
-                    "CreationTime": destination.creation_time,
-                    "LastModifiedTime": destination.creation_time,
-                }
-            ),
-            self.response_headers,
-        )
+    def delete_api_destination(self):
+        name = self._get_param("Name")
+        result = self.events_backend.delete_api_destination(name)
+        return json.dumps(result), self.response_headers


### PR DESCRIPTION
Work Done
---
This PR adds the `delete_api_destination`, `describe_api_destination` and `update_api_destination` to the events Response and Backend.
Also refactors creation to include `InvocationRateLimitPerSecond` 

Docs:
https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_CreateApiDestination.html
https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_DeleteApiDestination.html
https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_DescribeApiDestination.html
https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_UpdateApiDestination.html

Test
---
- [x] `TestAccAWSCloudWatchEventApiDestination_basic`
- [x] `TestAccAWSCloudWatchEventApiDestination_optional`
- [x] `TestAccAWSCloudWatchEventApiDestination_disappears`

![image](https://user-images.githubusercontent.com/32211561/126575573-1fcb29fb-864d-4f27-aa61-362ae1ab69f1.png)
