### PR TITLE
fix(events): store raw filter representation for event pattern

### DIFF
--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -644,13 +644,12 @@ class Destination(BaseModel):
 class EventPattern:
     def __init__(self, filter):
         self._filter = self._load_event_pattern(filter)
+        self._filter_raw = filter
         if not self._validate_event_pattern(self._filter):
             raise InvalidEventPatternException
 
     def __str__(self):
-        if self._filter:
-            return json.dumps(self._filter)
-        return str()
+        return self._filter_raw or str()
 
     def _load_event_pattern(self, pattern):
         try:


### PR DESCRIPTION
Work done
---
Add a new attribute `_filter_raw` in `EventPattern` just to make terraform happy when checking for plan. 

Open to discuss the approach :smile: 

Test
---
- [x] `TestAccAWSCloudWatchEventArchive_update`

![image](https://user-images.githubusercontent.com/32211561/126578783-e156009a-a704-49bf-ad49-39ab041b66e4.png)

<details>
<summary>How was this failing before? </summary>
<p>

```
    resource_aws_cloudwatch_event_archive_test.go:110: Step 2/2 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # aws_cloudwatch_event_archive.test will be updated in-place
          ~ resource "aws_cloudwatch_event_archive" "test" {
              ~ event_pattern    = jsonencode( # whitespace changes
                    {
                        source = [
                            "company.team.service",
                        ]
                    }
                )
                id               = "tf-acc-test-2478843715857287063"
                name             = "tf-acc-test-2478843715857287063"
                # (4 unchanged attributes hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
```
Note the `# whitespace changes` in the diff :joy: 

</p>
</details>  


> Yes, the commit has another conventional commit type haha, I decided to changed it :grin: 