### PR TITLE
Fix: Set SQS policy to None when setting it to an empty str via query parameters

### DIFF
--- a/moto/sqs/responses.py
+++ b/moto/sqs/responses.py
@@ -207,8 +207,8 @@ class SQSResponse(BaseResponse):
         # Fixes issue with Policy set to empty str
         if attribute_names:
             for attr in attribute_names:
-                if attr['Name'] == 'Policy' and attr['Value'] == '':
-                  attribute = {attr['Name']: None}
+                if attr['Name'] == 'Policy' and len(attr['Value']) == 0:
+                    attribute = {attr['Name']: None}
         queue_name = self._get_queue_name()
         self.sqs_backend.set_queue_attributes(queue_name, attribute)
 

--- a/moto/sqs/responses.py
+++ b/moto/sqs/responses.py
@@ -194,6 +194,7 @@ class SQSResponse(BaseResponse):
             raise InvalidAttributeName("")
 
         attribute_names = self._get_multi_param("AttributeName")
+
         attributes = self.sqs_backend.get_queue_attributes(queue_name, attribute_names)
 
         template = self.response_template(GET_QUEUE_ATTRIBUTES_RESPONSE)

--- a/moto/sqs/responses.py
+++ b/moto/sqs/responses.py
@@ -202,8 +202,14 @@ class SQSResponse(BaseResponse):
 
     def set_queue_attributes(self):
         # TODO validate self.get_param('QueueUrl')
+        attr_name = self.querystring.get('Attribute.1.Name')
+        attr_value = self.querystring.get('Attribute.1.Value')
+        if 'Policy' == attr_name[0] and len(attr_value[0]) == 0:
+          attribute = {attr_name[0]: None}
+        else:
+          attribute = self.attribute
         queue_name = self._get_queue_name()
-        self.sqs_backend.set_queue_attributes(queue_name, self.attribute)
+        self.sqs_backend.set_queue_attributes(queue_name, attribute)
 
         return SET_QUEUE_ATTRIBUTE_RESPONSE
 

--- a/moto/sqs/responses.py
+++ b/moto/sqs/responses.py
@@ -202,10 +202,10 @@ class SQSResponse(BaseResponse):
 
     def set_queue_attributes(self):
         # TODO validate self.get_param('QueueUrl')
-        attr_name = self.querystring.get('Attribute.1.Name')
-        attr_value = self.querystring.get('Attribute.1.Value')
-        if 'Policy' == attr_name[0] and len(attr_value[0]) == 0:
-          attribute = {attr_name[0]: None}
+        attr_name = self.querystring.get('Attribute.1.Name')[0]
+        attr_value = self.querystring.get('Attribute.1.Value')[0]
+        if attr_name == 'Policy' and len(attr_value) == 0:
+          attribute = {attr_name: None}
         else:
           attribute = self.attribute
         queue_name = self._get_queue_name()

--- a/moto/sqs/responses.py
+++ b/moto/sqs/responses.py
@@ -205,9 +205,9 @@ class SQSResponse(BaseResponse):
         attr_name = self.querystring.get('Attribute.1.Name')[0]
         attr_value = self.querystring.get('Attribute.1.Value')[0]
         if attr_name == 'Policy' and len(attr_value) == 0:
-          attribute = {attr_name: None}
+            attribute = {attr_name: None}
         else:
-          attribute = self.attribute
+            attribute = self.attribute
         queue_name = self._get_queue_name()
         self.sqs_backend.set_queue_attributes(queue_name, attribute)
 

--- a/moto/sqs/responses.py
+++ b/moto/sqs/responses.py
@@ -203,12 +203,14 @@ class SQSResponse(BaseResponse):
     def set_queue_attributes(self):
         # TODO validate self.get_param('QueueUrl')
         attribute = self.attribute
-        attribute_names = self._get_multi_param("Attribute")
+
         # Fixes issue with Policy set to empty str
+        attribute_names = self._get_multi_param("Attribute")
         if attribute_names:
             for attr in attribute_names:
                 if attr['Name'] == 'Policy' and len(attr['Value']) == 0:
                     attribute = {attr['Name']: None}
+
         queue_name = self._get_queue_name()
         self.sqs_backend.set_queue_attributes(queue_name, attribute)
 

--- a/moto/sqs/responses.py
+++ b/moto/sqs/responses.py
@@ -202,12 +202,17 @@ class SQSResponse(BaseResponse):
 
     def set_queue_attributes(self):
         # TODO validate self.get_param('QueueUrl')
-        attr_name = self.querystring.get('Attribute.1.Name')[0]
-        attr_value = self.querystring.get('Attribute.1.Value')[0]
-        if attr_name == 'Policy' and len(attr_value) == 0:
-            attribute = {attr_name: None}
-        else:
-            attribute = self.attribute
+        attribute = self.attribute
+        query_string_result = self.querystring
+        for key, value in query_string_result.items():
+            match = re.match(r"^Attribute\.(\d+)\.Name", key)
+            if match and 'Policy' in value[0]:
+                index = match.group(1)
+                attr_value = query_string_result.get(
+                  "Attribute.{}.Value".format(index)
+                )[0]
+                if len(attr_value) == 0:
+                  attribute = {value[0]: None}
         queue_name = self._get_queue_name()
         self.sqs_backend.set_queue_attributes(queue_name, attribute)
 


### PR DESCRIPTION
Fixes https://github.com/localstack/localstack/issues/4225

Fixes an issue with the terraform AWS provider that sets the SQS policy to an empty string, as seen in [the following function](https://github.com/hashicorp/terraform-provider-aws/blob/ccc13f55709c860a2130ecee6e21acde2318e936/aws/resource_aws_sqs_queue_policy.go#L104) via query parameters in the URL, for example:

`Action=SetQueueAttributes&Attribute.1.Name=Policy&Attribute.1.Value=&QueueUrl=http%3A%2F%2Flocalhost%3A4566%2F000000000000%2Fdistributor_queue&Version=2012-11-05`

In the end the `set_queue_attributes` receives the following:
```
odict_items([('Action', ['SetQueueAttributes']), ('Attribute.1.Name', ['Policy']), ('Attribute.1.Value', ['']), ('QueueUrl', ['http://localhost:4566/000000000000/distributor_queue']), ('Version', ['2012-11-05'])])
```