### PR TITLE
Small fix to not overwrite message attributes when being filtered

### DIFF
--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -857,12 +857,14 @@ class SQSBackend(BaseBackend):
 
                 queue.pending_messages.add(message)
                 message.mark_received(visibility_timeout=visibility_timeout)
-                _filter_message_attributes(message, message_attribute_names)
+                # Create deepcopy to not mutate the message state when filtering for attributes
+                message_copy = deepcopy(message)
+                _filter_message_attributes(message_copy, message_attribute_names)
                 if not self.is_message_valid_based_on_retention_period(
                     queue_name, message
                 ):
                     break
-                result.append(message)
+                result.append(message_copy)
                 if len(result) >= count:
                     break
 


### PR DESCRIPTION
Currently, when filtering for message attributes mutates the SQS State by deleting all non-filtered attributes. This change creates a deepcopy of a message and only applies the filter on the copy.
