### PR TITLE
Added Ubuntu focal & Amazon Linux V2 AMIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ test-only:
 
 test: lint test-only
 
+publish:
+	python setup.py sdist bdist_wheel
+	twine upload dist/*
+
 test_server:
 	@TEST_SERVER_MODE=true pytest -sv --cov=moto --cov-report xml ./tests/
 

--- a/README.md
+++ b/README.md
@@ -1,68 +1,34 @@
 # Moto - Mock AWS Services
 
-[![Join the chat at https://gitter.im/awsmoto/Lobby](https://badges.gitter.im/awsmoto/Lobby.svg)](https://gitter.im/awsmoto/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+Fork of [`moto`](https://github.com/spulec/moto) with changes and adaptations for [LocalStack](https://github.com/localstack/localstack).
 
-[![Build Status](https://github.com/spulec/moto/workflows/TestNDeploy/badge.svg)](https://github.com/spulec/moto/actions)
-[![Coverage Status](https://codecov.io/gh/spulec/moto/branch/master/graph/badge.svg)](https://codecov.io/gh/spulec/moto)
-[![Docs](https://readthedocs.org/projects/pip/badge/?version=stable)](http://docs.getmoto.org)
-[![PyPI](https://img.shields.io/pypi/v/moto.svg)](https://pypi.org/project/moto/)
-[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/moto.svg)](#)
-[![PyPI - Downloads](https://img.shields.io/pypi/dw/moto.svg)](https://pypistats.org/packages/moto)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+Please refer to the upstream repo for more details.
 
+## Releasing
 
-## Install
-
-```console
-$ pip install moto[ec2,s3,all]
+This fork is maintained as a separate pypi package, [moto-ext](https://pypi.org/project/moto-ext). To release a new version, follow these steps:
 ```
+# make sure to have git remotes defined for both repos: 
+$ git remote -v
+localstack	git@github.com:localstack/moto.git (fetch)
+localstack	git@github.com:localstack/moto.git (push)
+upstream	git@github.com:spulec/moto.git (fetch)
+upstream	git@github.com:spulec/moto.git (push)
 
-## In a nutshell
+# branch "master" is kept in sync with upstream "master"
+$ git checkout master
+$ git pull upstream master
 
+# branch "localstack" is the default branch of this repo
+$ git checkout localstack
+$ git rebase master  # resolve merge conflicts, if any...
+# (force-)push latest changes to the remote repo
+$ git push -f localstack localstack
 
-Moto is a library that allows your tests to easily mock out AWS Services.
-
-Imagine you have the following python code that you want to test:
-
-```python
-import boto3
-
-class MyModel(object):
-    def __init__(self, name, value):
-        self.name = name
-        self.value = value
-
-    def save(self):
-        s3 = boto3.client('s3', region_name='us-east-1')
-        s3.put_object(Bucket='mybucket', Key=self.name, Body=self.value)
+# update __version__, then publish to pypi
+$ vi moto/__init__.py
+...
+$ rm -rf dist/ build/
+$ make publish
+...
 ```
-
-Take a minute to think how you would have tested that in the past.
-
-Now see how you could test it with Moto:
-
-```python
-import boto3
-from moto import mock_s3
-from mymodule import MyModel
-
-@mock_s3
-def test_my_model_save():
-    conn = boto3.resource('s3', region_name='us-east-1')
-    # We need to create the bucket since this is all in Moto's 'virtual' AWS account
-    conn.create_bucket(Bucket='mybucket')
-    model_instance = MyModel('steve', 'is awesome')
-    model_instance.save()
-    body = conn.Object('mybucket', 'steve').get()['Body'].read().decode("utf-8")
-    assert body == 'is awesome'
-```
-
-With the decorator wrapping the test, all the calls to s3 are automatically mocked out. The mock keeps the state of the buckets and keys.
-
-For a full list of which services and features are covered, please see our [implementation coverage](https://github.com/spulec/moto/blob/master/IMPLEMENTATION_COVERAGE.md).
-
-
-### Documentation
-The full documentation can be found here:
-
-[http://docs.getmoto.org/en/latest/](http://docs.getmoto.org/en/latest/)

--- a/README.md
+++ b/README.md
@@ -15,13 +15,12 @@ localstack	git@github.com:localstack/moto.git (push)
 upstream	git@github.com:spulec/moto.git (fetch)
 upstream	git@github.com:spulec/moto.git (push)
 
-# branch "master" is kept in sync with upstream "master"
-$ git checkout master
-$ git pull upstream master
+# fetch fresh upstream "master" branch
+$ git fetch upstream master
 
 # branch "localstack" is the default branch of this repo
 $ git checkout localstack
-$ git rebase master  # resolve merge conflicts, if any...
+$ git rebase upstream/master  # resolve merge conflicts, if any...
 # (force-)push latest changes to the remote repo
 $ git push -f localstack localstack
 

--- a/moto/__init__.py
+++ b/moto/__init__.py
@@ -203,7 +203,7 @@ mock_all = MockAll
 # logging.getLogger('boto').setLevel(logging.CRITICAL)
 
 __title__ = "moto"
-__version__ = "2.2.19.dev"
+__version__ = "2.2.8"
 
 
 try:

--- a/moto/apigateway/responses.py
+++ b/moto/apigateway/responses.py
@@ -424,7 +424,7 @@ class APIGatewayResponse(BaseResponse):
             tags = self._get_param("tags")
             if tags:
                 stage = self.backend.get_stage(function_id, stage_name)
-                stage["tags"] = merge_multiple_dicts(stage.get("tags"), tags)
+                stage["tags"] = merge_multiple_dicts(stage.get("tags") or {}, tags)
             return 200, {}, json.dumps({"item": tags})
         if self.method == "DELETE":
             stage = self.backend.get_stage(function_id, stage_name)

--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -547,15 +547,8 @@ class Job(threading.Thread, BaseModel, DockerModel):
 
             log_config = docker.types.LogConfig(type=docker.types.LogConfig.types.JSON)
             self.job_state = "STARTING"
-            container = self.docker_client.containers.run(
-                image,
-                cmd,
-                detach=True,
-                name=name,
-                log_config=log_config,
-                environment=environment,
-                mounts=mounts,
-                privileged=privileged,
+            container = self.run_batch_container(
+                cmd, environment, image, log_config, mounts, name, privileged
             )
             self.job_state = "RUNNING"
             try:
@@ -650,6 +643,21 @@ class Job(threading.Thread, BaseModel, DockerModel):
                 )
             )
             self._mark_stopped(success=False)
+
+    def run_batch_container(
+        self, cmd, environment, image, log_config, mounts, name, privileged
+    ):
+        container = self.docker_client.containers.run(
+            image,
+            cmd,
+            detach=True,
+            name=name,
+            log_config=log_config,
+            environment=environment,
+            mounts=mounts,
+            privileged=privileged,
+        )
+        return container
 
     def _mark_stopped(self, success=True):
         # Ensure that job_stopped/job_stopped_at-attributes are set first

--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -464,8 +464,8 @@ class Job(threading.Thread, BaseModel, DockerModel):
             job_env = self.container_overrides.get(p, default)
             jd_env = self.job_definition.container_properties.get(p, default)
 
-            job_env_dict = {_env["name"]: _env["value"] for _env in job_env}
-            jd_env_dict = {_env["name"]: _env["value"] for _env in jd_env}
+            job_env_dict = {_env["name"]: _env.get("value") for _env in job_env}
+            jd_env_dict = {_env["name"]: _env.get("value") for _env in jd_env}
 
             for key in jd_env_dict.keys():
                 if key not in job_env_dict.keys():

--- a/moto/cloudwatch/models.py
+++ b/moto/cloudwatch/models.py
@@ -221,6 +221,8 @@ class MetricDatum(BaseModel):
             return False
 
         for metric in already_present_metrics or []:
+            if metric.namespace != self.namespace:
+                continue
             if self.dimensions and are_dimensions_same(
                 metric.dimensions, self.dimensions
             ):
@@ -539,7 +541,9 @@ class CloudWatchBackend(BaseBackend):
         # TODO: Also filter by unit and dimensions
         filtered_data = [
             md
-            for md in self.get_all_metrics()
+            for md in (
+                self.metric_data + self.aws_metric_data
+            )  # TODO: divergence from upstream
             if md.namespace == namespace
             and md.name == metric_name
             and start_time <= md.timestamp <= end_time

--- a/moto/ec2/exceptions.py
+++ b/moto/ec2/exceptions.py
@@ -680,6 +680,8 @@ class InvalidAssociationIDIamProfileAssociationError(EC2ClientError):
 
 
 class InvalidVpcEndPointIdError(EC2ClientError):
+    code = 404
+
     def __init__(self, vpc_end_point_id):
         super().__init__(
             "InvalidVpcEndpointId.NotFound",

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -1569,6 +1569,7 @@ class TagBackend(object):
                             value_filters.append(
                                 re.compile(simple_aws_filter_to_re(value))
                             )
+        # TODO: we should consider introducing proper locking here for synchronous access
         for resource_id, tags in self.tags.copy().items():
             for key, value in tags.items():
                 add_result = False

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -2111,6 +2111,23 @@ class RegionsAndZonesBackend(object):
                 zone_id="apse2-az2",
             ),
         ],
+        "ap-southeast-3": [
+            Zone(
+                region_name="ap-southeast-3",
+                name="ap-southeast-3a",
+                zone_id="apse3-az1",
+            ),
+            Zone(
+                region_name="ap-southeast-3",
+                name="ap-southeast-3b",
+                zone_id="apse3-az2",
+            ),
+            Zone(
+                region_name="ap-southeast-3",
+                name="ap-southeast-3c",
+                zone_id="apse3-az3",
+            ),
+        ],
         "eu-central-1": [
             Zone(region_name="eu-central-1", name="eu-central-1a", zone_id="euc1-az2"),
             Zone(region_name="eu-central-1", name="eu-central-1b", zone_id="euc1-az3"),

--- a/moto/ec2/resources/amis.json
+++ b/moto/ec2/resources/amis.json
@@ -644,5 +644,39 @@
     "name": "amzn-ami-minimal-hvm-2018.03.0.20181129-x86_64-ebs",
     "virtualization_type": "hvm",
     "hypervisor": "xen"
+  },
+  {
+    "ami_id": "ami-04dd4500af104442f",
+    "state": "available",
+    "public": true,
+    "owner_id": "137112412989",
+    "image_location": "amazon/amzn2-ami-kernel-5.10-hvm-2.0.20211201.0-x86_64-gp2",
+    "sriov": "simple",
+    "root_device_type": "ebs",
+    "root_device_name": "/dev/xvda",
+    "description": "Amazon Linux 2 Kernel 5.10 AMI 2.0.20211201.0 x86_64 HVM gp2",
+    "image_type": "machine",
+    "platform": "Linux/UNIX",
+    "architecture": "x86_64",
+    "name": "amzn2-ami-kernel-5.10-hvm-2.0.20211201.0-x86_64-gp2",
+    "virtualization_type": "hvm",
+    "hypervisor": "xen"
+  },
+  {
+    "ami_id": "ami-0fa7253564b0074bb",
+    "state": "available",
+    "public": true,
+    "owner_id": "099720109477",
+    "image_location": "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210413",
+    "sriov": "simple",
+    "root_device_type": "ebs",
+    "root_device_name": "/dev/sda1",
+    "description": "Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2021-04-13",
+    "image_type": "machine",
+    "platform": "Linux/UNIX",
+    "architecture": "x86_64",
+    "name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210413",
+    "virtualization_type": "hvm",
+    "hypervisor": "xen"
   }
 ]

--- a/moto/events/responses.py
+++ b/moto/events/responses.py
@@ -422,6 +422,7 @@ class EventsHandler(BaseResponse):
                     "ConnectionArn": connection.arn,
                     "ConnectionState": "AUTHORIZED",
                     "CreationTime": connection.creation_time,
+                    "Name": connection.name,
                     "LastModifiedTime": connection.creation_time,
                     "AuthorizationType": connection.authorization_type,
                 }

--- a/moto/iam/policy_validation.py
+++ b/moto/iam/policy_validation.py
@@ -98,11 +98,9 @@ class IAMPolicyDocumentValidator:
         try:
             self._validate_version()
         except Exception:
-            # whummer: skip raising an error here, as this is failing some of our TF examples
-            # raise MalformedPolicyDocument(
-            #     "Policy document must be version 2012-10-17 or greater."
-            # )
-            pass
+            raise MalformedPolicyDocument(
+                "Policy document must be version 2012-10-17 or greater."
+            )
         try:
             self._perform_first_legacy_parsing()
             self._validate_resources_for_formats()

--- a/moto/iam/policy_validation.py
+++ b/moto/iam/policy_validation.py
@@ -98,9 +98,11 @@ class IAMPolicyDocumentValidator:
         try:
             self._validate_version()
         except Exception:
-            raise MalformedPolicyDocument(
-                "Policy document must be version 2012-10-17 or greater."
-            )
+            # whummer: skip raising an error here, as this is failing some of our TF examples
+            # raise MalformedPolicyDocument(
+            #     "Policy document must be version 2012-10-17 or greater."
+            # )
+            pass
         try:
             self._perform_first_legacy_parsing()
             self._validate_resources_for_formats()

--- a/moto/iam/policy_validation.py
+++ b/moto/iam/policy_validation.py
@@ -98,11 +98,9 @@ class IAMPolicyDocumentValidator:
         try:
             self._validate_version()
         except Exception:
-            # whummer: skip raising an error here, as this is failing some of our TF examples
-            # raise MalformedPolicyDocument(
-            #     "Policy document must be version 2012-10-17 or greater."
-            # )
-            pass
+            raise MalformedPolicyDocument(
+                "Policy document must be version 2012-10-17 or greater."
+            )
         try:
             self._perform_first_legacy_parsing()
             self._validate_resources_for_formats()
@@ -145,10 +143,13 @@ class IAMPolicyDocumentValidator:
 
     def _validate_version_syntax(self):
         if "Version" in self._policy_json:
-            assert self._policy_json["Version"] in VALID_VERSIONS
+            assert self._policy_version() in VALID_VERSIONS
 
     def _validate_version(self):
-        assert self._policy_json["Version"] == "2012-10-17"
+        assert self._policy_version() == "2012-10-17"
+
+    def _policy_version(self):
+        return self._policy_json.get("Version")
 
     def _validate_sid_uniqueness(self):
         sids = []

--- a/moto/logs/responses.py
+++ b/moto/logs/responses.py
@@ -139,7 +139,7 @@ class LogsResponse(BaseResponse):
             "logGroupName",
             "Minimum length of 1. Maximum length of 512.",
             lambda x: 1 <= len(x) <= 512,
-            pattern="[.-_/#A-Za-z0-9]+$",
+            pattern=r"[\-._/#A-Za-z0-9]+$",
         )
 
         self.logs_backend.delete_metric_filter(filter_name, log_group_name)

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ extras_require.update(extras_per_service)
 
 
 setup(
-    name="moto",
+    name="moto-ext",
     version=get_version(),
     description="A library that allows your python tests to easily"
     " mock out the boto library",

--- a/tests/test_route53/test_route53.py
+++ b/tests/test_route53/test_route53.py
@@ -729,15 +729,15 @@ def test_hosted_zone_private_zone_preserved():
     # in (original) boto, these bools returned as strings.
     hosted_zone["GetHostedZoneResponse"]["HostedZone"]["Config"][
         "PrivateZone"
-    ].should.equal("True")
+    ].should.equal("true")
 
     hosted_zones = conn.get_all_hosted_zones()
     hosted_zones["ListHostedZonesResponse"]["HostedZones"][0]["Config"][
         "PrivateZone"
-    ].should.equal("True")
+    ].should.equal("true")
 
     zone = conn.get_zone("testdns.aws.com.")
-    zone.config["PrivateZone"].should.equal("True")
+    zone.config["PrivateZone"].should.equal("true")
 
 
 @mock_route53


### PR DESCRIPTION
I noticed that two popular AMI types were missing - Ubuntu Focal 20.04 & Amazon Linux V2.

I got the information straight from AWS with the following:
Ubuntu Focal:
`aws ec2 describe-images --owners "099720109477" --filters "Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"`

Amazon Linux V2
`aws ec2 describe-images --owners "amazon" --filters "Name=name,Values=amzn2-ami-kernel*"`

Then manually ported to the correct JSON format.