### PR TITLE
Use ISO timestamp in SES GetSendStatistics response

### DIFF
--- a/moto/ses/responses.py
+++ b/moto/ses/responses.py
@@ -436,7 +436,7 @@ GET_SEND_STATISTICS = """<GetSendStatisticsResponse xmlns="http://ses.amazonaws.
                 <Rejects>{{ statistics["Rejects"] }}</Rejects>
                 <Bounces>{{ statistics["Bounces"] }}</Bounces>
                 <Complaints>{{ statistics["Complaints"] }}</Complaints>
-                <Timestamp>{{ statistics["Timestamp"] }}</Timestamp>
+                <Timestamp>{{ statistics["Timestamp"].isoformat() }}</Timestamp>
             </item>
         {% endfor %}
       </SendDataPoints>


### PR DESCRIPTION
This PR makes use of ISO format to represent timestamps in the GetSendStatistics response.

Currently timestamps are templated to standard Python datetime string representation:

```
2022-02-04 13:44:05,486 - MainThread - botocore.parsers - DEBUG - Response body:
b'<GetSendStatisticsResponse xmlns="http://ses.amazonaws.com/doc/2010-12-01/"><GetSendStatisticsResult><SendDataPoints><item><DeliveryAttempts>0</DeliveryAttempts><Rejects>0</Rejects><Bounces>0</Bounces><Complaints>0</Complaints><Timestamp>2022-02-04 08:14:05.474570</Timestamp></item></SendDataPoints></GetSendStatisticsResult><ResponseMetadata><RequestId>e0abcdfa-c866-11e0-b6d0-273d09173z49</RequestId></ResponseMetadata></GetSendStatisticsResponse>'
2022-02-04 13:44:05,487 - MainThread - botocore.hooks - DEBUG - Event needs-retry.ses.GetSendStatistics: calling handler <botocore.retryhandler.RetryHandler object at 0x7faeb1f12df0>
2022-02-04 13:44:05,487 - MainThread - botocore.retryhandler - DEBUG - No retry needed.
2022-02-04 13:44:05,487 - MainThread - awscli.formatter - DEBUG - RequestId: e0abcdfa-c866-11e0-b6d0-273d09173z49
{
    "SendDataPoints": [
        {
            "Timestamp": "2022-02-04 08:14:05.474570",
            "DeliveryAttempts": 0,
            "Bounces": 0,
            "Complaints": 0,
            "Rejects": 0
        }
    ]
}
```
This PR changes it to use ISO 8601 format:
```
2022-02-04 13:46:35,833 - MainThread - botocore.parsers - DEBUG - Response body:
b'<GetSendStatisticsResponse xmlns="http://ses.amazonaws.com/doc/2010-12-01/"><GetSendStatisticsResult><SendDataPoints><item><DeliveryAttempts>0</DeliveryAttempts><Rejects>0</Rejects><Bounces>0</Bounces><Complaints>0</Complaints><Timestamp>2022-02-04T08:16:35.819531</Timestamp></item></SendDataPoints></GetSendStatisticsResult><ResponseMetadata><RequestId>e0abcdfa-c866-11e0-b6d0-273d09173z49</RequestId></ResponseMetadata></GetSendStatisticsResponse>'
2022-02-04 13:46:35,833 - MainThread - botocore.hooks - DEBUG - Event needs-retry.ses.GetSendStatistics: calling handler <botocore.retryhandler.RetryHandler object at 0x7f2b6df8bdf0>
2022-02-04 13:46:35,833 - MainThread - botocore.retryhandler - DEBUG - No retry needed.
2022-02-04 13:46:35,833 - MainThread - awscli.formatter - DEBUG - RequestId: e0abcdfa-c866-11e0-b6d0-273d09173z49
{
    "SendDataPoints": [
        {
            "Timestamp": "2022-02-04T08:16:35.819531",
            "DeliveryAttempts": 0,
            "Bounces": 0,
            "Complaints": 0,
            "Rejects": 0
        }
    ]
}
```

Closes localstack/localstack#3645