### PR TITLE
Remove dependency to cfn-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,9 @@ terraformtests:
 	cd tests/terraformtests && bin/run_go_test $(SERVICE_NAME) "$(TEST_NAMES)"
 
 publish:
-	python setup.py sdist bdist_wheel
-	twine upload dist/*
+	. .venv/bin/activate; \
+		python setup.py sdist bdist_wheel; \
+		twine upload dist/*
 
 test_server:
 	@TEST_SERVER_MODE=true pytest -sv --cov=moto --cov-report xml ./tests/

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,8 @@ all_extra_deps = [
     _dep_jsondiff,
     _dep_aws_xray_sdk,
     _dep_idna,
-    _dep_cfn_lint,
+    # removing cfn-lint for now, to save ~138MB
+    # _dep_cfn_lint,
     _dep_sshpubkeys,
     _dep_pyparsing,
     _setuptools,
@@ -87,7 +88,11 @@ extras_per_service.update(
         "appsync": [_dep_graphql],
         "awslambda": [_dep_docker],
         "batch": [_dep_docker],
-        "cloudformation": [_dep_docker, _dep_PyYAML, _dep_cfn_lint],
+        "cloudformation": [
+            _dep_docker, _dep_PyYAML,
+            # removing cfn-lint for now, to save ~138MB
+            # _dep_cfn_lint
+        ],
         "cognitoidp": [_dep_python_jose, _dep_python_jose_ecdsa_pin],
         "ec2": [_dep_sshpubkeys],
         "glue": [_dep_pyparsing],

--- a/tests/test_cloudformation/test_validate.py
+++ b/tests/test_cloudformation/test_validate.py
@@ -2,6 +2,7 @@ import json
 import boto3
 import botocore
 import sure  # noqa # pylint: disable=unused-import
+import pytest
 
 from moto import mock_cloudformation, mock_s3
 from tests import EXAMPLE_AMI_ID
@@ -40,6 +41,9 @@ json_bad_template = {"AWSTemplateFormatVersion": "2010-09-09", "Description": "S
 
 dummy_template_json = json.dumps(json_template)
 dummy_bad_template_json = json.dumps(json_bad_template)
+
+# skip tests in this module, as we skip importing cfn-lint
+pytestmark = pytest.mark.skip()
 
 
 @mock_cloudformation


### PR DESCRIPTION
Remove the dependency to `cfn-lint`, to save some space in the LocalStack Docker image:
```
# du -h -d 0 /opt/code/localstack/.venv/lib/python3.10/site-packages/cfnlint
138M	/opt/code/localstack/.venv/lib/python3.10/site-packages/cfnlint
```

This is safe to remove for our purposes - the only place where cfnlint is imported is inside [validate_template_cfn_lint(..)](https://github.com/spulec/moto/blob/e911341e6ad1bfe7f3930f38c36b26b25cdb0f94/moto/cloudformation/utils.py#L62-L64), which we're not currently making use of (our CloudFormation provider returns a mocked result for `validate_template(..)`).

As discussed - if and when we introduce `cfn-lint` for our own CloudFormation implementation, we can prune the `cfnlint/data/CloudSpecs/...` folder and leave only `us-east-1.json` as the canonical region in there (reducing the total size to ~14MB). There are some minor differences between the region specs, those should not be super relevant for us at this stage, though. 👍 

TODO: 
- [x] adjust tests in this repo to gracefully handle validation/import errors