### PR TITLE
Making it possible to encrypt using ARNs of KMS key aliases.

### DIFF
--- a/moto/kms/models.py
+++ b/moto/kms/models.py
@@ -237,7 +237,7 @@ class KmsBackend(BaseBackend):
     def get_alias_name(alias_name):
         # Allow use of ARN as well as alias name
         if alias_name.startswith("arn:") and ":alias/" in alias_name:
-            return alias_name.split(":alias/")[1]
+            return "alias/" + alias_name.split(":alias/")[1]
 
         return alias_name
 

--- a/tests/test_kms/test_model.py
+++ b/tests/test_kms/test_model.py
@@ -1,0 +1,52 @@
+import pytest
+
+from moto.kms.models import KmsBackend
+
+PLAINTEXT = b"text"
+REGION = "us-east-1"
+
+
+@pytest.fixture
+def backend():
+    return KmsBackend(REGION)
+
+
+@pytest.fixture
+def key(backend):
+    return backend.create_key(
+        None, "ENCRYPT_DECRYPT", "SYMMETRIC_DEFAULT", "Test key", None, REGION
+    )
+
+
+def test_encrypt_key_id(backend, key):
+    ciphertext, arn = backend.encrypt(key.id, PLAINTEXT, {})
+
+    assert ciphertext is not None
+    assert arn == key.arn
+
+
+def test_encrypt_key_arn(backend, key):
+    ciphertext, arn = backend.encrypt(key.arn, PLAINTEXT, {})
+
+    assert ciphertext is not None
+    assert arn == key.arn
+
+
+def test_encrypt_alias_name(backend, key):
+    backend.add_alias(key.id, "alias/test/test")
+
+    ciphertext, arn = backend.encrypt("alias/test/test", PLAINTEXT, {})
+
+    assert ciphertext is not None
+    assert arn == key.arn
+
+
+def test_encrypt_alias_arn(backend, key):
+    backend.add_alias(key.id, "alias/test/test")
+
+    ciphertext, arn = backend.encrypt(
+        f"arn:aws:kms:{REGION}:{key.account_id}:alias/test/test", PLAINTEXT, {}
+    )
+
+    assert ciphertext is not None
+    assert arn == key.arn


### PR DESCRIPTION
Addresses https://github.com/localstack/localstack/issues/6471
KMS is supposed to allow to use ARNs of key aliases for encryption/decryption. Unfortunately, while it is true in the upstream moto repository, in our fork it was broken.

This PR simply replaces one line in models.py with the corresponding liтe from the upstream repository. And copies from the upstream repository one test file as-is, as that file has tests that cover this behavior.