### PR TITLE
fix ELBv2 - add valid attribute and fix set_ip_address_type possibles values

### DIFF
--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -525,6 +525,7 @@ class FakeLoadBalancer(CloudFormationModel):
         "load_balancing.cross_zone.enabled",
         "routing.http.desync_mitigation_mode",
         "routing.http.drop_invalid_header_fields.enabled",
+        "routing.http.preserve_host_header.enabled",
         "routing.http.x_amzn_tls_version_and_cipher_suite.enabled",
         "routing.http.xff_client_port.enabled",
         "routing.http2.enabled",
@@ -1341,10 +1342,10 @@ Member must satisfy regular expression pattern: {}".format(
         return modified_rules
 
     def set_ip_address_type(self, arn, ip_type):
-        if ip_type not in ("internal", "dualstack"):
+        if ip_type not in ("ipv4", "dualstack"):
             raise RESTError(
-                "InvalidParameterValue",
-                "IpAddressType must be either internal | dualstack",
+                "ValidationError",
+                f"1 validation error detected: Value '{ip_type}' at 'ipAddressType' failed to satisfy constraint: Member must satisfy enum value set: [ipv4, dualstack]",
             )
 
         balancer = self.load_balancers.get(arn)


### PR DESCRIPTION
A user encountered an error while trying to set up an ALB resource with Terraform:

```
Error: failure configuring LB attributes: :
│       status code: 400, request id: 7a62c49f-347e-4fc4-9331-6e8eEXAMPLE
│
│   with aws_lb.this,
│   on [load_balancer.tf](http://load_balancer.tf/) line 58, in resource "aws_lb" "this":
│   58: resource "aws_lb" "this" {  

resource "aws_lb" "this" {
  name               = "nginx-lb"
  internal           = false
  load_balancer_type = "application"
  security_groups    = [aws_security_group.db_instance.id]
  subnets            = data.aws_subnets.default.ids

  enable_deletion_protection = true

  tags = {
    Environment = "production"
  }
}
```
Error message from Terraform:
```json
{"@level":"debug","@message":"-----------------------------------------------------","@module":"provider.terraform-provider-aws_v4.28.0_x5","@timestamp":"2022-08-31T13:01:32.352817+04:00"}
{"@level":"debug","@message":"[DEBUG] [aws-sdk-go] \u003c?xml version=\"1.0\" encoding=\"UTF-8\"?\u003e","@module":"provider.terraform-provider-aws_v4.28.0_x5","@timestamp":"2022-08-31T13:01:32.352827+04:00"}
{"@level":"debug","@message":"  \u003cErrorResponse\u003e","@module":"provider.terraform-provider-aws_v4.28.0_x5","@timestamp":"2022-08-31T13:01:32.352837+04:00"}
{"@level":"debug","@message":"    \u003cErrors\u003e","@module":"provider.terraform-provider-aws_v4.28.0_x5","@timestamp":"2022-08-31T13:01:32.352847+04:00"}
{"@level":"debug","@message":"      \u003cError\u003e","@module":"provider.terraform-provider-aws_v4.28.0_x5","@timestamp":"2022-08-31T13:01:32.352857+04:00"}
{"@level":"debug","@message":"        \u003cCode\u003eInvalidConfigurationRequest\u003c/Code\u003e","@module":"provider.terraform-provider-aws_v4.28.0_x5","@timestamp":"2022-08-31T13:01:32.352867+04:00"}
{"@level":"debug","@message":"        \u003cMessage\u003e\u003c![CDATA[Key routing.http.preserve_host_header.enabled not valid]]\u003e\u003c/Message\u003e","@module":"provider.terraform-provider-aws_v4.28.0_x5","@timestamp":"2022-08-31T13:01:32.352882+04:00"}
{"@level":"debug","@message":"        ","@module":"provider.terraform-provider-aws_v4.28.0_x5","@timestamp":"2022-08-31T13:01:32.352897+04:00"}
{"@level":"debug","@message":"      \u003c/Error\u003e","@module":"provider.terraform-provider-aws_v4.28.0_x5","@timestamp":"2022-08-31T13:01:32.352913+04:00"}
{"@level":"debug","@message":"    \u003c/Errors\u003e","@module":"provider.terraform-provider-aws_v4.28.0_x5","@timestamp":"2022-08-31T13:01:32.352925+04:00"}
{"@level":"debug","@message":"  \u003cRequestId\u003e7a62c49f-347e-4fc4-9331-6e8eEXAMPLE\u003c/RequestId\u003e","@module":"provider.terraform-provider-aws_v4.28.0_x5","@timestamp":"2022-08-31T13:01:32.352939+04:00"}
{"@level":"debug","@message":"\u003c/ErrorResponse\u003e","@module":"provider.terraform-provider-aws_v4.28.0_x5","@timestamp":"2022-08-31T13:01:32.352951+04:00"}
{"@level":"debug","@message":"[DEBUG] [aws-sdk-go] DEBUG: Validate Response elasticloadbalancing/ModifyLoadBalancerAttributes failed, attempt 0/25, error : ","@module":"provider.terraform-provider-aws_v4.28.0_x5","@timestamp":"2022-08-31T13:01:32.352966+04:00"}
{"@level":"debug","@message":"\tstatus code: 400, request id: 7a62c49f-347e-4fc4-9331-6e8eEXAMPLE","@module":"provider.terraform-provider-aws_v4.28.0_x5","@timestamp":"2022-08-31T13:01:32.352979+04:00"}
```
Error from Localstack:
```
2022-08-31T08:15:08.520  INFO --- [   asgi_gw_0] localstack.request.aws     : AWS elbv2.ModifyLoadBalancerAttributes => 400 (InvalidConfigurationRequest); ModifyLoadBalancerAttributesInput({'LoadBalancerArn': 'arn:aws:elasticloadbalancing:eu-west-1:000000000000:loadbalancer/app/TEST-20220831090102313200000002/b33a0ccc', 'Attributes': [{'Key': 'idle_timeout.timeout_seconds', 'Value': '60'}, {'Key': 'routing.http2.enabled', 'Value': 'true'}, {'Key': 'routing.http.drop_invalid_header_fields.enabled', 'Value': 'false'}, {'Key': 'routing.http.preserve_host_header.enabled', 'Value': 'false'}, {'Key': 'routing.http.desync_mitigation_mode', 'Value': 'defensive'}, {'Key': 'deletion_protection.enabled', 'Value': 'false'}]}, headers={'Host': 'localhost:4566', 'User-Agent': 'APN/1.0 HashiCorp/1.0 Terraform/1.2.8 (+https://www.terraform.io) terraform-provider-aws/dev (+https://registry.terraform.io/providers/hashicorp/aws) aws-sdk-go/1.44.84 (go1.18.4; linux; amd64)', 'Content-Length': '737', 'Authorization': 'AWS4-HMAC-SHA256 Credential=test/20220831/eu-west-1/elasticloadbalancing/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-date, Signature=069809035b819e239a0d36b42d1c311ae2752bc9bbd2791978d90e9255698564', 'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8', 'X-Amz-Date': '20220831T090132Z', 'Accept-Encoding': 'gzip', 'x-localstack-tgt-api': 'elbv2'}); InvalidConfigurationRequest(Key routing.http.preserve_host_header.enabled not valid, headers={'Content-Type': 'application/xml', 'server': 'amazon.com', 'X-Amzn-ErrorType': 'InvalidConfigurationRequest', 'status': '400', 'Content-Length': '343', 'Connection': 'close', 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Methods': 'HEAD,GET,PUT,POST,DELETE,OPTIONS,PATCH', 'Access-Control-Allow-Headers': 'authorization,cache-control,content-length,content-md5,content-type,etag,location,x-amz-acl,x-amz-content-sha256,x-amz-date,x-amz-request-id,x-amz-security-token,x-amz-tagging,x-amz-target,x-amz-user-agent,x-amz-version-id,x-amzn-requestid,x-localstack-target,amz-sdk-invocation-id,amz-sdk-request', 'Access-Control-Expose-Headers': 'etag,x-amz-version-id'})
```
I reproduced the issue with https://github.com/terraform-aws-modules/terraform-aws-alb/tree/master/examples/complete-alb 
An attribute was missing in the set of `VALID_ATTRS` for the `modify_load_balancer_attributes` operation. This could have been fixed with a simple patch in the `elbv2` provider. 
But another issue arose after this fix, one of the 2 possibles values for `set_ip_address_type` was wrong (`ipv4` instead of `internal`) and would cause Terraform to error. 
So both fixes are done with the same PR, as they allow the Terraform plan to be created. 

AWS docs for both operation:
SetIpAddressType: https://awscli.amazonaws.com/v2/documentation/api/latest/reference/elbv2/set-ip-address-type.html
ModifyLoadBalancerAttributes: https://awscli.amazonaws.com/v2/documentation/api/latest/reference/elbv2/modify-load-balancer-attributes.html