### PR TITLE
IAM detach_user_policy error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,10 @@ terraformtests:
 	@echo ""
 	cd tests/terraformtests && bin/run_go_test $(SERVICE_NAME) "$(TEST_NAMES)"
 
+publish:
+	python setup.py sdist bdist_wheel
+	twine upload dist/*
+
 test_server:
 	@TEST_SERVER_MODE=true pytest -sv --cov=moto --cov-report xml ./tests/
 

--- a/README.md
+++ b/README.md
@@ -1,68 +1,34 @@
 # Moto - Mock AWS Services
 
-[![Join the chat at https://gitter.im/awsmoto/Lobby](https://badges.gitter.im/awsmoto/Lobby.svg)](https://gitter.im/awsmoto/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+Fork of [`moto`](https://github.com/spulec/moto) with changes and adaptations for [LocalStack](https://github.com/localstack/localstack).
 
-[![Build Status](https://github.com/spulec/moto/workflows/TestNDeploy/badge.svg)](https://github.com/spulec/moto/actions)
-[![Coverage Status](https://codecov.io/gh/spulec/moto/branch/master/graph/badge.svg)](https://codecov.io/gh/spulec/moto)
-[![Docs](https://readthedocs.org/projects/pip/badge/?version=stable)](http://docs.getmoto.org)
-[![PyPI](https://img.shields.io/pypi/v/moto.svg)](https://pypi.org/project/moto/)
-[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/moto.svg)](#)
-[![PyPI - Downloads](https://img.shields.io/pypi/dw/moto.svg)](https://pypistats.org/packages/moto)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+Please refer to the upstream repo for more details.
 
+## Releasing
 
-## Install
+This fork is maintained as a separate pypi package, [moto-ext](https://pypi.org/project/moto-ext). To release a new version, follow these steps:
 
-```console
-$ pip install 'moto[ec2,s3,all]'
 ```
+# make sure to have git remotes defined for both repos: 
+$ git remote -v
+localstack	git@github.com:localstack/moto.git (fetch)
+localstack	git@github.com:localstack/moto.git (push)
+upstream	git@github.com:spulec/moto.git (fetch)
+upstream	git@github.com:spulec/moto.git (push)
 
-## In a nutshell
+# fetch fresh upstream "master" branch
+$ git fetch upstream master
 
+# branch "localstack" is the default branch of this repo
+$ git checkout localstack
+$ git rebase upstream/master  # resolve merge conflicts, if any...
+# (force-)push latest changes to the remote repo
+$ git push -f localstack localstack
 
-Moto is a library that allows your tests to easily mock out AWS Services.
-
-Imagine you have the following python code that you want to test:
-
-```python
-import boto3
-
-class MyModel(object):
-    def __init__(self, name, value):
-        self.name = name
-        self.value = value
-
-    def save(self):
-        s3 = boto3.client('s3', region_name='us-east-1')
-        s3.put_object(Bucket='mybucket', Key=self.name, Body=self.value)
+# update __version__, then publish to pypi
+$ vi moto/__init__.py
+...
+$ rm -rf dist/ build/
+$ make publish
+...
 ```
-
-Take a minute to think how you would have tested that in the past.
-
-Now see how you could test it with Moto:
-
-```python
-import boto3
-from moto import mock_s3
-from mymodule import MyModel
-
-@mock_s3
-def test_my_model_save():
-    conn = boto3.resource('s3', region_name='us-east-1')
-    # We need to create the bucket since this is all in Moto's 'virtual' AWS account
-    conn.create_bucket(Bucket='mybucket')
-    model_instance = MyModel('steve', 'is awesome')
-    model_instance.save()
-    body = conn.Object('mybucket', 'steve').get()['Body'].read().decode("utf-8")
-    assert body == 'is awesome'
-```
-
-With the decorator wrapping the test, all the calls to s3 are automatically mocked out. The mock keeps the state of the buckets and keys.
-
-For a full list of which services and features are covered, please see our [implementation coverage](https://github.com/spulec/moto/blob/master/IMPLEMENTATION_COVERAGE.md).
-
-
-### Documentation
-The full documentation can be found here:
-
-[http://docs.getmoto.org/en/latest/](http://docs.getmoto.org/en/latest/)

--- a/moto/apigateway/responses.py
+++ b/moto/apigateway/responses.py
@@ -404,7 +404,7 @@ class APIGatewayResponse(BaseResponse):
             tags = self._get_param("tags")
             if tags:
                 stage = self.backend.get_stage(function_id, stage_name)
-                stage["tags"] = merge_multiple_dicts(stage.get("tags"), tags)
+                stage["tags"] = merge_multiple_dicts(stage.get("tags") or {}, tags)
             return 200, {}, json.dumps({"item": tags})
         if self.method == "DELETE":
             stage = self.backend.get_stage(function_id, stage_name)

--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -520,8 +520,8 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
             job_env = self.container_overrides.get(p, default)
             jd_env = self.job_definition.container_properties.get(p, default)
 
-            job_env_dict = {_env["name"]: _env["value"] for _env in job_env}
-            jd_env_dict = {_env["name"]: _env["value"] for _env in jd_env}
+            job_env_dict = {_env["name"]: _env.get("value") for _env in job_env}
+            jd_env_dict = {_env["name"]: _env.get("value") for _env in jd_env}
 
             for key in jd_env_dict.keys():
                 if key not in job_env_dict.keys():

--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -644,16 +644,15 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
             while self.status == "STARTING":
                 # Wait until the state is no longer runnable, but 'RUNNING'
                 sleep(0.5)
-            container = self.docker_client.containers.run(
-                image,
+            container = self.run_batch_container(
                 cmd,
-                detach=True,
-                name=name,
-                log_config=log_config,
-                environment=environment,
-                mounts=mounts,
-                privileged=privileged,
-                extra_hosts=extra_hosts,
+                environment,
+                image,
+                log_config,
+                mounts,
+                name,
+                privileged,
+                extra_hosts,
                 **run_kwargs,
             )
             try:
@@ -750,6 +749,32 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
                 )
             )
             self._mark_stopped(success=False)
+
+    def run_batch_container(
+        self,
+        cmd,
+        environment,
+        image,
+        log_config,
+        mounts,
+        name,
+        privileged,
+        extra_hosts,
+        **run_kwargs,
+    ):
+        container = self.docker_client.containers.run(
+            image,
+            cmd,
+            detach=True,
+            name=name,
+            log_config=log_config,
+            environment=environment,
+            mounts=mounts,
+            privileged=privileged,
+            extra_hosts=extra_hosts,
+            **run_kwargs,
+        )
+        return container
 
     def _mark_stopped(self, success=True):
         # Ensure that job_stopped/job_stopped_at-attributes are set first

--- a/moto/cloudwatch/models.py
+++ b/moto/cloudwatch/models.py
@@ -544,7 +544,9 @@ class CloudWatchBackend(BaseBackend):
         period_delta = timedelta(seconds=period)
         filtered_data = [
             md
-            for md in self.get_all_metrics()
+            for md in (
+                self.metric_data + self.aws_metric_data
+            )  # TODO: divergence from upstream
             if md.namespace == namespace
             and md.name == metric_name
             and start_time <= md.timestamp <= end_time

--- a/moto/ec2/exceptions.py
+++ b/moto/ec2/exceptions.py
@@ -753,6 +753,8 @@ class InvalidAssociationIDIamProfileAssociationError(EC2ClientError):
 
 
 class InvalidVpcEndPointIdError(EC2ClientError):
+    code = 404
+
     def __init__(self, vpc_end_point_id):
         super().__init__(
             "InvalidVpcEndpointId.NotFound",

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -525,6 +525,7 @@ class FakeLoadBalancer(CloudFormationModel):
         "load_balancing.cross_zone.enabled",
         "routing.http.desync_mitigation_mode",
         "routing.http.drop_invalid_header_fields.enabled",
+        "routing.http.preserve_host_header.enabled",
         "routing.http.x_amzn_tls_version_and_cipher_suite.enabled",
         "routing.http.xff_client_port.enabled",
         "routing.http2.enabled",
@@ -1341,10 +1342,10 @@ Member must satisfy regular expression pattern: {}".format(
         return modified_rules
 
     def set_ip_address_type(self, arn, ip_type):
-        if ip_type not in ("internal", "dualstack"):
+        if ip_type not in ("ipv4", "dualstack"):
             raise RESTError(
-                "InvalidParameterValue",
-                "IpAddressType must be either internal | dualstack",
+                "ValidationError",
+                f"1 validation error detected: Value '{ip_type}' at 'ipAddressType' failed to satisfy constraint: Member must satisfy enum value set: [ipv4, dualstack]",
             )
 
         balancer = self.load_balancers.get(arn)

--- a/moto/emr/models.py
+++ b/moto/emr/models.py
@@ -168,6 +168,7 @@ class FakeCluster(BaseModel):
         security_configuration=None,
         kerberos_attributes=None,
         auto_scaling_role=None,
+        ebs_root_volume_size=10,
     ):
         self.id = cluster_id or random_cluster_id()
         emr_backend.clusters[self.id] = self
@@ -200,34 +201,43 @@ class FakeCluster(BaseModel):
             "master_instance_type" in instance_attrs
             and instance_attrs["master_instance_type"]
         ):
-            self.emr_backend.add_instance_groups(
+            instance_groups = [
+                {
+                    "instance_count": 1,
+                    "instance_role": "MASTER",
+                    "instance_type": instance_attrs["master_instance_type"],
+                    "market": "ON_DEMAND",
+                    "name": "master",
+                }
+            ]
+            instance_group_result = self.emr_backend.add_instance_groups(
                 self.id,
-                [
-                    {
-                        "instance_count": 1,
-                        "instance_role": "MASTER",
-                        "instance_type": instance_attrs["master_instance_type"],
-                        "market": "ON_DEMAND",
-                        "name": "master",
-                    }
-                ],
+                instance_groups,
+            )
+            self.emr_backend.add_instances(
+                self.id, instance_groups[0], instance_group_result[0]
             )
         if (
             "slave_instance_type" in instance_attrs
             and instance_attrs["slave_instance_type"]
         ):
-            self.emr_backend.add_instance_groups(
+            instance_groups = [
+                {
+                    "instance_count": instance_attrs["instance_count"] - 1,
+                    "instance_role": "CORE",
+                    "instance_type": instance_attrs["slave_instance_type"],
+                    "market": "ON_DEMAND",
+                    "name": "slave",
+                }
+            ]
+            instance_group_result = self.emr_backend.add_instance_groups(
                 self.id,
-                [
-                    {
-                        "instance_count": instance_attrs["instance_count"] - 1,
-                        "instance_role": "CORE",
-                        "instance_type": instance_attrs["slave_instance_type"],
-                        "market": "ON_DEMAND",
-                        "name": "slave",
-                    }
-                ],
+                instance_groups,
             )
+            for i in range(0, len(instance_group_result)):
+                self.emr_backend.add_instances(
+                    self.id, instance_groups[i], instance_group_result[i]
+                )
         self.additional_master_security_groups = instance_attrs.get(
             "additional_master_security_groups"
         )
@@ -276,12 +286,25 @@ class FakeCluster(BaseModel):
         )
         self.kerberos_attributes = kerberos_attributes
         self.auto_scaling_role = auto_scaling_role
+        self.ebs_root_volume_size = ebs_root_volume_size
 
     @property
     def arn(self):
         return "arn:aws:elasticmapreduce:{0}:{1}:cluster/{2}".format(
             self.emr_backend.region_name, self.emr_backend.account_id, self.id
         )
+
+    @property
+    def master_public_dns_name(self):
+        master_group_id = self.master_instance_group_id
+        master_instance = [
+            i for i in self.instances if i.instance_group.id == master_group_id
+        ]
+        # add region into the domain name after the IP (results in something like: ec2-184-0-0-1.us-west-1.compute.amazonaws.com)
+        parts = master_instance[0].details.public_dns.split(
+            "."
+        )  # there should always be at least one master instance available here
+        return ".".join([parts[0], self.emr_backend.region_name, *parts[1:]])
 
     @property
     def instance_groups(self):
@@ -437,6 +460,8 @@ class ElasticMapReduceBackend(BaseBackend):
             instance = FakeInstance(
                 ec2_instance_id=instance.id, instance_group=instance_group
             )
+            # set details so we have the same behavior as in list_instances
+            instance.details = self.ec2_backend.get_instance(instance.ec2_instance_id)
             cluster.add_instance(instance)
 
     def add_job_flow_steps(self, job_flow_id, steps):

--- a/moto/emr/responses.py
+++ b/moto/emr/responses.py
@@ -280,6 +280,7 @@ class ElasticMapReduceResponse(BaseResponse):
             job_flow_role=self._get_param("JobFlowRole"),
             service_role=self._get_param("ServiceRole"),
             auto_scaling_role=self._get_param("AutoScalingRole"),
+            ebs_root_volume_size=self._get_param("EbsRootVolumeSize", 10),
             steps=steps_from_query_string(self._get_list_prefix("Steps.member")),
             visible_to_all_users=self._get_bool_param("VisibleToAllUsers", False),
             instance_attrs=instance_attrs,
@@ -583,7 +584,12 @@ DESCRIBE_CLUSTER_TEMPLATE = """<DescribeClusterResponse xmlns="http://elasticmap
         </member>
         {% endfor %}
       </Applications>
+      {% if cluster.keep_job_flow_alive_when_no_steps is not none %}
       <AutoTerminate>{{ (not cluster.keep_job_flow_alive_when_no_steps)|lower }}</AutoTerminate>
+      {% endif %}
+      <EbsRootVolumeSize>
+      {{ cluster.ebs_root_volume_size }}
+      </EbsRootVolumeSize>
       <Configurations>
         {% for configuration in cluster.configurations %}
         <member>
@@ -639,8 +645,10 @@ DESCRIBE_CLUSTER_TEMPLATE = """<DescribeClusterResponse xmlns="http://elasticmap
         <ADDomainJoinPassword>{{ cluster.kerberos_attributes['ADDomainJoinPassword'] }}</ADDomainJoinPassword>
         {% endif %}
       </KerberosAttributes>
+      {% if cluster.log_uri is not none %}
       <LogUri>{{ cluster.log_uri }}</LogUri>
-      <MasterPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MasterPublicDnsName>
+      {% endif %}
+      <MasterPublicDnsName>{{ cluster.master_public_dns_name }}</MasterPublicDnsName>
       <Name>{{ cluster.name }}</Name>
       <NormalizedInstanceHours>{{ cluster.normalized_instance_hours }}</NormalizedInstanceHours>
       {% if cluster.release_label is not none %}
@@ -656,7 +664,9 @@ DESCRIBE_CLUSTER_TEMPLATE = """<DescribeClusterResponse xmlns="http://elasticmap
       <SecurityConfiguration>{{ cluster.security_configuration }}</SecurityConfiguration>
       {% endif %}
       <ServiceRole>{{ cluster.service_role }}</ServiceRole>
+      {% if cluster.auto_scaling_role is not none %}
       <AutoScalingRole>{{ cluster.auto_scaling_role }}</AutoScalingRole>
+      {% endif %}
       <Status>
         <State>{{ cluster.state }}</State>
         <StateChangeReason>

--- a/moto/events/responses.py
+++ b/moto/events/responses.py
@@ -425,6 +425,7 @@ class EventsHandler(BaseResponse):
                     "ConnectionArn": connection.arn,
                     "ConnectionState": "AUTHORIZED",
                     "CreationTime": connection.creation_time,
+                    "Name": connection.name,
                     "LastModifiedTime": connection.creation_time,
                     "AuthorizationType": connection.authorization_type,
                 }

--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -1761,6 +1761,8 @@ class IAMBackend(BaseBackend):
         arns = dict((p.arn, p) for p in self.managed_policies.values())
         try:
             policy = arns[policy_arn]
+            if policy.arn not in self.get_user(user_name).managed_policies.keys():
+                raise KeyError
         except KeyError:
             raise IAMNotFoundException("Policy {0} was not found.".format(policy_arn))
         policy.detach_from(self.get_user(user_name))

--- a/moto/iam/policy_validation.py
+++ b/moto/iam/policy_validation.py
@@ -139,10 +139,13 @@ class BaseIAMPolicyValidator:
 
     def _validate_version_syntax(self):
         if "Version" in self._policy_json:
-            assert self._policy_json["Version"] in VALID_VERSIONS
+            assert self._policy_version() in VALID_VERSIONS
 
     def _validate_version(self):
-        assert self._policy_json["Version"] == "2012-10-17"
+        assert self._policy_version() == "2012-10-17"
+
+    def _policy_version(self):
+        return self._policy_json.get("Version")
 
     def _validate_sid_uniqueness(self):
         sids = []

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ extras_require.update(extras_per_service)
 
 
 setup(
-    name="moto",
+    name="moto-ext",
     version=get_version(),
     description="A library that allows your python tests to easily"
     " mock out the boto library",


### PR DESCRIPTION
fix https://github.com/localstack/localstack/issues/6989

Existing un-attached user policy throwed a 500 InternalError unexpectedly, whilst non-existing user policy throwed 404 IAMNotFoundException as expected.
![image](https://user-images.githubusercontent.com/29195190/195106405-2c78d241-86e9-4db8-bb7e-a1a6a2326a7b.png)

This can be solved by checking if the user is linked with the policy-arn given.
![image](https://user-images.githubusercontent.com/29195190/195114085-92711c6e-3f23-4787-b2ba-47950c5aeacc.png)

Other things to consider include:
- This problem seems to apply to other `detach_*_policy` implementations inside code, such as group and role. _Should we open another issue to resolve these?_
- May you please add the `hacktoberfest-accepted` tag to this PR if possible? Thank you.