### PR TITLE
Handle HostedZoneConfig.VPC is None

### DIFF
--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -44,7 +44,8 @@ class Route53(BaseResponse):
             if "HostedZoneConfig" in zone_request:
                 zone_config = zone_request["HostedZoneConfig"]
                 comment = zone_config["Comment"]
-                if zone_request.get("VPC", {}).get("VPCId", None):
+                vpc = zone_request.get("VPC", {}) or {}
+                if vpc.get("VPCId", None):
                     private_zone = True
                 else:
                     private_zone = self._convert_to_bool(


### PR DESCRIPTION
This code path is triggered when a HostedZoneConfig property is added to
the Route53 hosted zone configuration, but there is no VPC element. For
some reason it's `None` rather than being absent, but this works around
it.
