### PR TITLE
Handle HostedZoneConfig.VPC is None

### DIFF
--- a/docs/docs/services/sagemaker.rst
+++ b/docs/docs/services/sagemaker.rst
@@ -313,7 +313,7 @@ sagemaker
 - [ ] update_monitoring_schedule
 - [ ] update_notebook_instance
 - [ ] update_notebook_instance_lifecycle_config
-- [ ] update_pipeline
+- [X] update_pipeline
 - [ ] update_pipeline_execution
 - [ ] update_project
 - [ ] update_space

--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -44,7 +44,8 @@ class Route53(BaseResponse):
             if "HostedZoneConfig" in zone_request:
                 zone_config = zone_request["HostedZoneConfig"]
                 comment = zone_config["Comment"]
-                if zone_request.get("VPC", {}).get("VPCId", None):
+                vpc = zone_request.get("VPC", {}) or {}
+                if vpc.get("VPCId", None):
                     private_zone = True
                 else:
                     private_zone = self._convert_to_bool(

--- a/moto/sagemaker/models.py
+++ b/moto/sagemaker/models.py
@@ -1787,6 +1787,40 @@ class SageMakerModelBackend(BaseBackend):
         del self.pipelines[pipeline_name]
         return pipeline_arn
 
+    def update_pipeline(
+        self,
+        pipeline_name,
+        **kwargs,
+    ):
+        try:
+            pipeline_arn = self.pipelines[pipeline_name].pipeline_arn
+        except KeyError:
+            raise ValidationError(
+                message=f"Could not find pipeline with name {pipeline_name}."
+            )
+
+        provided_kwargs = set(kwargs.keys())
+        allowed_kwargs = {
+            "pipeline_display_name",
+            "pipeline_definition",
+            "pipeline_definition_s3_location",
+            "pipeline_description",
+            "role_arn",
+            "parallelism_configuration",
+        }
+        invalid_kwargs = provided_kwargs - allowed_kwargs
+
+        if invalid_kwargs:
+            raise TypeError(
+                f"update_pipeline got unexpected keyword arguments '{invalid_kwargs}'"
+            )
+
+        for attr_key, attr_value in kwargs.items():
+            if attr_value:
+                setattr(self.pipelines[pipeline_name], attr_key, attr_value)
+
+        return pipeline_arn
+
     def list_pipelines(
         self,
         pipeline_name_prefix,

--- a/moto/sagemaker/responses.py
+++ b/moto/sagemaker/responses.py
@@ -494,6 +494,23 @@ class SageMakerResponse(BaseResponse):
         return 200, {}, json.dumps(response)
 
     @amzn_request_id
+    def update_pipeline(self):
+        pipeline_arn = self.sagemaker_backend.update_pipeline(
+            pipeline_name=self._get_param("PipelineName"),
+            pipeline_display_name=self._get_param("PipelineDisplayName"),
+            pipeline_definition=self._get_param("PipelineDefinition"),
+            pipeline_definition_s3_location=self._get_param(
+                "PipelineDefinitionS3Location"
+            ),
+            pipeline_description=self._get_param("PipelineDescription"),
+            role_arn=self._get_param("RoleArn"),
+            parallelism_configuration=self._get_param("ParallelismConfiguration"),
+        )
+
+        response = {"PipelineArn": pipeline_arn}
+        return 200, {}, json.dumps(response)
+
+    @amzn_request_id
     def list_pipelines(self):
         max_results_range = range(1, 101)
         allowed_sort_by = ("Name", "CreationTime")


### PR DESCRIPTION
This code path is triggered when a HostedZoneConfig property is added to the Route53 hosted zone configuration, but there is no VPC element. For some reason it's `None` rather than being absent.

This patch handles that case.

See https://github.com/localstack/localstack/issues/7341
