### PR TITLE
add SNS subscription attributes validation for FilterPolicyScope + nested validation of FilterPolicy

### DIFF
--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -778,6 +778,7 @@ class SNSBackend(BaseBackend):
             "RawMessageDelivery",
             "DeliveryPolicy",
             "FilterPolicy",
+            "FilterPolicyScope",
             "RedrivePolicy",
             "SubscriptionRoleArn",
         ]:

--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -811,7 +811,7 @@ class SNSBackend(BaseBackend):
                 if not isinstance(_value, list):
                     if scope == "MessageBody":
                         # From AWS docs: "unlike attribute-based policies, payload-based policies support property nesting."
-                        _rules.extend(aggregate_rules(_value, depth=depth+1))
+                        _rules.extend(aggregate_rules(_value, depth=depth + 1))
                     else:
                         raise SNSInvalidParameter(
                             "Invalid parameter: Filter policy scope MessageAttributes does not support nested filter policy"
@@ -828,8 +828,8 @@ class SNSBackend(BaseBackend):
             )
 
         aggregated_rules = aggregate_rules(value)
-        # Even the official documentation states the total combination of values must not exceed 100, in reality it is 150
-        # https://docs.aws.amazon.com/sns/latest/dg/sns-subscription-filter-policies.html#subscription-filter-policy-constraints
+        # For the complexity of the filter policy, the total combination of values must not exceed 150.
+        # https://docs.aws.amazon.com/sns/latest/dg/subscription-filter-policy-constraints.html
         if combinations > 150:
             raise SNSInvalidParameter(
                 "Invalid parameter: FilterPolicy: Filter policy is too complex"
@@ -859,6 +859,7 @@ class SNSBackend(BaseBackend):
                             )
                         continue
                     elif keyword == "numeric":
+                        # TODO: validate conditions
                         continue
                     elif keyword == "prefix":
                         continue

--- a/moto/sns/responses.py
+++ b/moto/sns/responses.py
@@ -224,6 +224,12 @@ class SNSResponse(BaseResponse):
         subscription = self.backend.subscribe(topic_arn, endpoint, protocol)
 
         if attributes is not None:
+            # We need to set the FilterPolicyScope first, as the validation of the FilterPolicy will depend on it
+            if "FilterPolicyScope" in attributes:
+                filter_policy_scope = attributes.pop("FilterPolicyScope")
+                self.backend.set_subscription_attributes(
+                    subscription.arn, "FilterPolicyScope", filter_policy_scope)
+
             for attr_name, attr_value in attributes.items():
                 self.backend.set_subscription_attributes(
                     subscription.arn, attr_name, attr_value

--- a/moto/sns/responses.py
+++ b/moto/sns/responses.py
@@ -228,7 +228,8 @@ class SNSResponse(BaseResponse):
             if "FilterPolicyScope" in attributes:
                 filter_policy_scope = attributes.pop("FilterPolicyScope")
                 self.backend.set_subscription_attributes(
-                    subscription.arn, "FilterPolicyScope", filter_policy_scope)
+                    subscription.arn, "FilterPolicyScope", filter_policy_scope
+                )
 
             for attr_name, attr_value in attributes.items():
                 self.backend.set_subscription_attributes(

--- a/tests/test_sns/test_subscriptions_boto3.py
+++ b/tests/test_sns/test_subscriptions_boto3.py
@@ -250,7 +250,6 @@ def test_creating_subscription_with_attributes():
     filter_policy = json.dumps(
         {
             "store": ["example_corp"],
-            "event": ["order_cancelled"],
             "encrypted": [False],
             "customer_interests": ["basketball", "baseball"],
             "price": [100, 100.12],
@@ -371,7 +370,6 @@ def test_set_subscription_attributes():
     filter_policy = json.dumps(
         {
             "store": ["example_corp"],
-            "event": ["order_cancelled"],
             "encrypted": [False],
             "customer_interests": ["basketball", "baseball"],
             "price": [100, 100.12],

--- a/tests/test_sns/test_subscriptions_boto3.py
+++ b/tests/test_sns/test_subscriptions_boto3.py
@@ -483,7 +483,9 @@ def test_subscribe_invalid_filter_policy():
             TopicArn=topic_arn,
             Protocol="http",
             Endpoint="http://example.com/",
-            Attributes={"FilterPolicy": json.dumps({"store": {"key": [{"exists": None}]}})},
+            Attributes={
+                "FilterPolicy": json.dumps({"store": {"key": [{"exists": None}]}})
+            },
         )
     except ClientError as err:
         err.response["Error"]["Code"].should.equal("InvalidParameter")
@@ -515,7 +517,9 @@ def test_subscribe_invalid_filter_policy():
     try:
         nested_filter_policy = {
             "key_a": {
-                "key_b": {"key_c": ["value_one", "value_two", "value_three", "value_four"]},
+                "key_b": {
+                    "key_c": ["value_one", "value_two", "value_three", "value_four"]
+                },
             },
             "key_d": {"key_e": ["value_one", "value_two", "value_three"]},
             "key_f": ["value_one", "value_two", "value_three"],
@@ -527,13 +531,17 @@ def test_subscribe_invalid_filter_policy():
             TopicArn=topic_arn,
             Protocol="http",
             Endpoint="http://example.com/",
-            Attributes={"FilterPolicyScope": "MessageBody", "FilterPolicy": json.dumps(nested_filter_policy)},
+            Attributes={
+                "FilterPolicyScope": "MessageBody",
+                "FilterPolicy": json.dumps(nested_filter_policy),
+            },
         )
     except ClientError as err:
         err.response["Error"]["Code"].should.equal("InvalidParameter")
         err.response["Error"]["Message"].should.equal(
             "Invalid parameter: FilterPolicy: Filter policy is too complex"
         )
+
 
 @mock_sns
 def test_check_not_opted_out():

--- a/tests/test_sns/test_subscriptions_boto3.py
+++ b/tests/test_sns/test_subscriptions_boto3.py
@@ -478,6 +478,62 @@ def test_subscribe_invalid_filter_policy():
     except ClientError as err:
         err.response["Error"]["Code"].should.equal("InternalFailure")
 
+    try:
+        conn.subscribe(
+            TopicArn=topic_arn,
+            Protocol="http",
+            Endpoint="http://example.com/",
+            Attributes={"FilterPolicy": json.dumps({"store": {"key": [{"exists": None}]}})},
+        )
+    except ClientError as err:
+        err.response["Error"]["Code"].should.equal("InvalidParameter")
+        err.response["Error"]["Message"].should.equal(
+            "Invalid parameter: Filter policy scope MessageAttributes does not support nested filter policy"
+        )
+
+    try:
+        filter_policy = {
+            "key_a": ["value_one"],
+            "key_b": ["value_two"],
+            "key_c": ["value_three"],
+            "key_d": ["value_four"],
+            "key_e": ["value_five"],
+            "key_f": ["value_six"],
+        }
+        conn.subscribe(
+            TopicArn=topic_arn,
+            Protocol="http",
+            Endpoint="http://example.com/",
+            Attributes={"FilterPolicy": json.dumps(filter_policy)},
+        )
+    except ClientError as err:
+        err.response["Error"]["Code"].should.equal("InvalidParameter")
+        err.response["Error"]["Message"].should.equal(
+            "Invalid parameter: FilterPolicy: Filter policy can not have more than 5 keys"
+        )
+
+    try:
+        nested_filter_policy = {
+            "key_a": {
+                "key_b": {"key_c": ["value_one", "value_two", "value_three", "value_four"]},
+            },
+            "key_d": {"key_e": ["value_one", "value_two", "value_three"]},
+            "key_f": ["value_one", "value_two", "value_three"],
+        }
+        # The first array has four values in a three-level nested key, and the second has three values in a two-level
+        # nested key. The total combination is calculated as follows:
+        # 3 x 4 x 2 x 3 x 1 x 3 = 216
+        conn.subscribe(
+            TopicArn=topic_arn,
+            Protocol="http",
+            Endpoint="http://example.com/",
+            Attributes={"FilterPolicyScope": "MessageBody", "FilterPolicy": json.dumps(nested_filter_policy)},
+        )
+    except ClientError as err:
+        err.response["Error"]["Code"].should.equal("InvalidParameter")
+        err.response["Error"]["Message"].should.equal(
+            "Invalid parameter: FilterPolicy: Filter policy is too complex"
+        )
 
 @mock_sns
 def test_check_not_opted_out():


### PR DESCRIPTION
AWS recently added a new feature to SNS (around end of November 22), concerning the `FilterPolicy` of subscriptions.
Previously, when filtering messages going to be fanned out to subscribers, we could only filter on `MessageAttributes`. However, this was a limitation especially between their own integrations: S3 notifications for example. You don't have a say in how the event looks, and can't add message attributes.
They introduced the `FilterPolicyScope` subscription attribute, and you can now choose between `MessageAttributes` (the default) and `MessageBody`. This will require the body to be a parsable JSON string, but you can now filter based on the message body. 

You can read more with examples here:
https://aws.amazon.com/blogs/compute/introducing-payload-based-message-filtering-for-amazon-sns/

We don't use the notifications system from moto, as it's implemented on LocalStack.
I'm modifying the validation here, allowing the new attribute `FilterScopePolicy` to be set.

Also, as we already validate the `FilterPolicy` in moto, I've added the new validation for the policy when the scope is set to `MessageBody`: it can now contains nested properties. There are snapshot tests in the LocalStack PR linked. https://github.com/localstack/localstack/pull/7408
