### PR TITLE
rework S3 object ACL

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -528,9 +528,7 @@ class FakeAcl(BaseModel):
                     if grantee.uri:
                         grant_list.append(
                             {
-                                "grantee": grantee.uri.split(
-                                    "http://acs.amazonaws.com/groups/s3/"
-                                )[1],
+                                "grantee": grantee.uri.rsplit("/", maxsplit=1)[1],
                                 "permission": CAMEL_CASED_PERMISSIONS[permission],
                             }
                         )
@@ -561,9 +559,8 @@ def get_canned_acl(acl):
     elif acl == "public-read":
         grants.append(FakeGrant([ALL_USERS_GRANTEE], [PERMISSION_READ]))
     elif acl == "public-read-write":
-        grants.append(
-            FakeGrant([ALL_USERS_GRANTEE], [PERMISSION_READ, PERMISSION_WRITE])
-        )
+        grants.append(FakeGrant([ALL_USERS_GRANTEE], [PERMISSION_READ]))
+        grants.append(FakeGrant([ALL_USERS_GRANTEE], [PERMISSION_WRITE]))
     elif acl == "authenticated-read":
         grants.append(FakeGrant([AUTHENTICATED_USERS_GRANTEE], [PERMISSION_READ]))
     elif acl == "bucket-owner-read":
@@ -573,9 +570,9 @@ def get_canned_acl(acl):
     elif acl == "aws-exec-read":
         pass  # TODO: bucket owner, EC2 Read
     elif acl == "log-delivery-write":
-        grants.append(
-            FakeGrant([LOG_DELIVERY_GRANTEE], [PERMISSION_READ_ACP, PERMISSION_WRITE])
-        )
+        grants.append(FakeGrant([LOG_DELIVERY_GRANTEE], [PERMISSION_READ_ACP]))
+        grants.append(FakeGrant([LOG_DELIVERY_GRANTEE], [PERMISSION_WRITE]))
+
     else:
         assert False, f"Unknown canned acl: {acl}"
     return FakeAcl(grants=grants)

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -505,6 +505,17 @@ class FakeAcl(BaseModel):
                     return True
         return False
 
+    def __eq__(self, other):
+        """
+        User-defined classes always compare unequal except to themselves by default. Using the `config_dict` allows
+        to check for equality in ACLs.
+        :param other: another FakeAcl object to compare to
+        :return: a boolean indicating equality
+        """
+        if not isinstance(other, FakeAcl):
+            return False
+        return self.to_config_dict() == other.to_config_dict()
+
     def __repr__(self):
         return f"FakeAcl(grants: {self.grants})"
 
@@ -2171,6 +2182,10 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         bucket_key_enabled=False,
         mdirective=None,
     ):
+        print(src_key, dest_key_name)
+        print(storage, src_key.storage_class)
+        print(acl, src_key.acl)
+        print(encryption, src_key.encryption)
         if (
             src_key.name == dest_key_name
             and src_key.bucket_name == dest_bucket_name

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -2182,10 +2182,6 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         bucket_key_enabled=False,
         mdirective=None,
     ):
-        print(src_key, dest_key_name)
-        print(storage, src_key.storage_class)
-        print(acl, src_key.acl)
-        print(encryption, src_key.encryption)
         if (
             src_key.name == dest_key_name
             and src_key.bucket_name == dest_bucket_name

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1323,6 +1323,10 @@ class S3Response(BaseResponse):
 
     def _key_response_put(self, request, body, bucket_name, query, key_name):
         self._set_action("KEY", "PUT", query)
+        # TODO: work on ACL, anonymous users are allowed to upload objects to public bucket, not currently supported
+        # because of unsupported "anonymous" user.
+        # An object created by an anon user in a public bucket will be public. If created by an authenticated user,
+        # by default those objects will be private and owned by the creating user
         self._authenticate_and_authorize_s3_action()
 
         response_headers = {}
@@ -1552,6 +1556,8 @@ class S3Response(BaseResponse):
         metadata = metadata_from_headers(request.headers)
         metadata.update(metadata_from_headers(query))
         new_key.set_metadata(metadata)
+        # TODO: if the user is anonymous in a public bucket, the canned ACL should be `public`
+        # not currently supported (always-on default credentials)
         new_key.set_acl(acl or get_canned_acl("private"))
         new_key.website_redirect_location = request.headers.get(
             "x-amz-website-redirect-location"
@@ -1995,6 +2001,8 @@ class S3Response(BaseResponse):
             metadata = metadata_from_headers(request.headers)
             tagging = self._tagging_from_headers(request.headers)
             storage_type = request.headers.get("x-amz-storage-class", "STANDARD")
+            # TODO: if the user is anonymous in a public bucket, the canned ACL should be `public`
+            # not currently supported (always-on default credentials)
             acl = self._acl_from_headers(request.headers) or get_canned_acl("private")
 
             multipart_id = self.backend.create_multipart_upload(

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1512,13 +1512,12 @@ class S3Response(BaseResponse):
                 )
 
                 mdirective = request.headers.get("x-amz-metadata-directive")
-
                 self.backend.copy_object(
                     key,
                     bucket_name,
                     key_name,
                     storage=storage_class,
-                    acl=acl,
+                    acl=acl or get_canned_acl("private"),
                     kms_key_id=kms_key_id,
                     encryption=encryption,
                     bucket_key_enabled=bucket_key_enabled,

--- a/tests/test_s3/test_s3_acl.py
+++ b/tests/test_s3/test_s3_acl.py
@@ -86,7 +86,8 @@ def test_s3_object_in_public_bucket():
     bucket.create(
         ACL="public-read", CreateBucketConfiguration={"LocationConstraint": "us-west-1"}
     )
-    bucket.put_object(Body=b"ABCD", Key="file.txt")
+    # by default, a file created by an authenticated user in a public bucket will be private
+    bucket.put_object(Body=b"ABCD", Key="file.txt", ACL="public-read")
 
     s3_anonymous = boto3.resource("s3")
     s3_anonymous.meta.client.meta.events.register("choose-signer.s3.*", disable_signing)
@@ -98,7 +99,9 @@ def test_s3_object_in_public_bucket():
     )
     contents.should.equal(b"ABCD")
 
-    bucket.put_object(ACL="private", Body=b"ABCD", Key="file.txt")
+    # the object will be created private by default
+    # TODO: support an anonymous user to create an object in a public bucket, it should have `public` ACL
+    bucket.put_object(Body=b"ABCD", Key="file.txt")
 
     with pytest.raises(ClientError) as exc:
         s3_anonymous.Object(key="file.txt", bucket_name="test-bucket").get()


### PR DESCRIPTION
This PR is reworking S3 Object ACL, needed for https://github.com/localstack/localstack/pull/7409

Several issues are present in Moto handling of ACL:

- Object are inheriting bucket ACL, which is not the normal behaviour from AWS. Even if the bucket is public, objects created by an authenticated user will be private and owned by the user by default. Only objects created by anonymous users will be public (the anonymous part is not implemented yet because of default credentials being used, making the user always authenticated for now. This will be a feature to work on in the future). 
- ACL Grants being badly generated, making it an issue to actually render them. 
- Being able to compare ACL between each other, needed for the LS PR and for `CopyObject`. 

I've also modified the tests to actually test the normal default behaviour, like AWS. We have many tests in the LS repo which tests default ACL the same way. Fixing this allows us to remove an `xfail` mark on a snapshotted test. 