### PR TITLE
remove double CI runs for every pull request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,12 @@
 name: TestNDeploy
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'README.md'
+    branches:
+      - localstack
+  pull_request:
 
 jobs:
   cache:

--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -1,6 +1,12 @@
 name: DockerTests
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'README.md'
+    branches:
+      - localstack
+  pull_request:
 
 jobs:
   cache:

--- a/.github/workflows/test_terraform.yml
+++ b/.github/workflows/test_terraform.yml
@@ -1,4 +1,10 @@
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'README.md'
+    branches:
+      - localstack
+  pull_request:
 name: TestTerraform
 jobs:
   prepare_list:


### PR DESCRIPTION
Change configuration of GH Actions to only run the CI pipeline on pull request actions, and push on `localstack` branch.

After @simonrw noticed that moto-ext CI runs take a really long time, I've also noticed that when I pushed commits it would take extremely long. When checking the config, it seemed we launched some Actions twice when opening and pushing commits on a PR.

After having a look with @alexrashed, it seems this is not an issue on upstream as they don't have branches living in the base repo, so no `push` action is triggered. 