### PR TITLE
stream handling compatibility

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -135,8 +135,9 @@ class FakeKey(BaseModel, ManagedState):
         )
         self._value_buffer = tempfile.SpooledTemporaryFile(self._max_buffer_size)
         self.disposed = False
-        self.value = value  # type: ignore
+        self.checksum_value = checksum_value
         self.lock = threading.Lock()
+        self.value = value  # type: ignore
 
         self.encryption = encryption
         self.kms_key_id = kms_key_id
@@ -145,7 +146,6 @@ class FakeKey(BaseModel, ManagedState):
         self.lock_mode = lock_mode
         self.lock_legal_status = lock_legal_status
         self.lock_until = lock_until
-        self.checksum_value = checksum_value
 
         # Default metadata values
         self._metadata["Content-Type"] = "binary/octet-stream"

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -506,7 +506,7 @@ class FakeAcl(BaseModel):
                     return True
         return False
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         """
         User-defined classes always compare unequal except to themselves by default. Using the `config_dict` allows
         to check for equality in ACLs.

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -506,7 +506,7 @@ class FakeAcl(BaseModel):
                     return True
         return False
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other):
         """
         User-defined classes always compare unequal except to themselves by default. Using the `config_dict` allows
         to check for equality in ACLs.

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1679,17 +1679,17 @@ class S3Response(BaseResponse):
                     "x-amz-copy-source-version-id"
                 ] = key_to_copy.version_id
 
-            # checksum stuff, do we need to compute hash of the copied object
-            checksum_algorithm = request.headers.get("x-amz-checksum-algorithm")
-            if checksum_algorithm:
-                checksum_value = compute_checksum(
-                    new_key.value, algorithm=checksum_algorithm
-                ).decode("utf-8")
-                response_headers.update(
-                    {"Checksum": {f"Checksum{checksum_algorithm}": checksum_value}}
-                )
-                new_key.checksum_algorithm = checksum_algorithm
-                new_key.checksum_value = checksum_value
+            # Commented out to be compatible with stream handling: we are doing it on our provider
+            # checksum_algorithm = request.headers.get("x-amz-checksum-algorithm")
+            # if checksum_algorithm:
+            #     checksum_value = compute_checksum(
+            #         new_key.value, algorithm=checksum_algorithm
+            #     ).decode("utf-8")
+            #     response_headers.update(
+            #         {"Checksum": {f"Checksum{checksum_algorithm}": checksum_value}}
+            #     )
+            #     new_key.checksum_algorithm = checksum_algorithm
+            #     new_key.checksum_value = checksum_value
 
             template = self.response_template(S3_OBJECT_COPY_RESPONSE)
             response_headers.update(new_key.response_dict)

--- a/tests/test_s3/test_s3_copyobject.py
+++ b/tests/test_s3/test_s3_copyobject.py
@@ -38,6 +38,7 @@ def test_copy_key_boto3(key_name):
     resp["Body"].read().should.equal(b"some value")
 
 
+@pytest.mark.xfail(reason="Logic implemented in LocalStack S3 provider")
 @mock_s3
 def test_copy_key_boto3_with_sha256_checksum():
     # Setup
@@ -773,6 +774,7 @@ def test_copy_key_boto3_with_both_sha256_checksum(algorithm):
 
 
 @mock_s3
+@pytest.mark.xfail(reason="logic moved into LocalStack S3 provider")
 @pytest.mark.parametrize(
     "algorithm, checksum",
     [


### PR DESCRIPTION
This PR introduces minimal changes to allow patching moto in localstack for stream handling.

We remove the checksum validation for CopyObject but this is added back in our provider, with streaming checksum calculation possible.

Also changed the order when setting FakeKey attributes, in order for them to be usable in the property setter of value.

Created an `__init__.py` file in `moto_server` because I had issue when running `make entrypoints`, python couldn't locate the module. 

Depending on https://github.com/localstack/localstack/pull/8498 for the checksum handling in `CopyObject`

https://github.com/localstack/localstack/pull/8473 depends on this PR to be able to run successfully. 