### PR TITLE
Fix service names in BackendDict initialisations

### DIFF
--- a/moto/acm/models.py
+++ b/moto/acm/models.py
@@ -550,4 +550,4 @@ class AWSCertificateManagerBackend(BaseBackend):
         return certificate, certificate_chain, private_key
 
 
-acm_backends = BackendDict(AWSCertificateManagerBackend, "ec2")
+acm_backends = BackendDict(AWSCertificateManagerBackend, "acm")

--- a/moto/applicationautoscaling/models.py
+++ b/moto/applicationautoscaling/models.py
@@ -530,4 +530,6 @@ class FakeScheduledAction(BaseModel):
         self.end_time = end_time
 
 
-applicationautoscaling_backends = BackendDict(ApplicationAutoscalingBackend, "application-autoscaling")
+applicationautoscaling_backends = BackendDict(
+    ApplicationAutoscalingBackend, "application-autoscaling"
+)

--- a/moto/applicationautoscaling/models.py
+++ b/moto/applicationautoscaling/models.py
@@ -530,4 +530,4 @@ class FakeScheduledAction(BaseModel):
         self.end_time = end_time
 
 
-applicationautoscaling_backends = BackendDict(ApplicationAutoscalingBackend, "ec2")
+applicationautoscaling_backends = BackendDict(ApplicationAutoscalingBackend, "application-autoscaling")

--- a/moto/elb/models.py
+++ b/moto/elb/models.py
@@ -657,4 +657,4 @@ class ELBBackend(BaseBackend):
 
 
 # Use the same regions as EC2
-elb_backends = BackendDict(ELBBackend, "ec2")
+elb_backends = BackendDict(ELBBackend, "elb")

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -1743,4 +1743,4 @@ Member must satisfy regular expression pattern: {expression}"
         return resource
 
 
-elbv2_backends = BackendDict(ELBv2Backend, "ec2")
+elbv2_backends = BackendDict(ELBv2Backend, "elbv2")

--- a/moto/opsworks/models.py
+++ b/moto/opsworks/models.py
@@ -627,4 +627,4 @@ class OpsWorksBackend(BaseBackend):
         self.instances[instance_id].start()
 
 
-opsworks_backends = BackendDict(OpsWorksBackend, "ec2")
+opsworks_backends = BackendDict(OpsWorksBackend, "opsworks")

--- a/moto/signer/models.py
+++ b/moto/signer/models.py
@@ -197,4 +197,4 @@ class SignerBackend(BaseBackend):
 
 # Using the lambda-regions
 # boto3.Session().get_available_regions("signer") still returns an empty list
-signer_backends = BackendDict(SignerBackend, "lambda")
+signer_backends = BackendDict(SignerBackend, "signer")


### PR DESCRIPTION
(cherry picked from commit ae43a69dba0b4919b72506f6e50a406e65462338).

As briefly discussed with @viren-nadkarni.