### PR TITLE
Feature/add gov cloud to ssm

### DIFF
--- a/moto/ssm/resources/ami-amazon-linux-latest/us-gov-east-1.json
+++ b/moto/ssm/resources/ami-amazon-linux-latest/us-gov-east-1.json
@@ -1,0 +1,191 @@
+[
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-east-1::parameter/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-arm64",
+        "DataType": "text",
+        "LastModifiedDate": 1721692759.417,
+        "Name": "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-arm64",
+        "Type": "String",
+        "Value": "ami-0388cfad0bfbabb99",
+        "Version": 50
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-east-1::parameter/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64",
+        "DataType": "text",
+        "LastModifiedDate": 1721692760.492,
+        "Name": "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64",
+        "Type": "String",
+        "Value": "ami-045a9bf9ced62bc2f",
+        "Version": 50
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-east-1::parameter/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-6.1-x86_64",
+        "DataType": "text",
+        "LastModifiedDate": 1721692760.222,
+        "Name": "/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-6.1-x86_64",
+        "Type": "String",
+        "Value": "ami-0dbef5e1adb6e1abf",
+        "Version": 50
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-east-1::parameter/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-default-arm64",
+        "DataType": "text",
+        "LastModifiedDate": 1721692760.983,
+        "Name": "/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-default-arm64",
+        "Type": "String",
+        "Value": "ami-06cfed33cc8526f2d",
+        "Version": 50
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-east-1::parameter/aws/service/ami-amazon-linux-latest/amzn-ami-minimal-hvm-x86_64-s3",
+        "DataType": "text",
+        "LastModifiedDate": 1703012167.998,
+        "Name": "/aws/service/ami-amazon-linux-latest/amzn-ami-minimal-hvm-x86_64-s3",
+        "Type": "String",
+        "Value": "ami-0a4c808d4c1a4bd8b",
+        "Version": 67
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-east-1::parameter/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-arm64-gp2",
+        "DataType": "text",
+        "LastModifiedDate": 1721697389.518,
+        "Name": "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-arm64-gp2",
+        "Type": "String",
+        "Value": "ami-0ad9a80ec3dceacee",
+        "Version": 85
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-east-1::parameter/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-ebs",
+        "DataType": "text",
+        "LastModifiedDate": 1721697389.822,
+        "Name": "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-ebs",
+        "Type": "String",
+        "Value": "ami-0aeefe7aca43006af",
+        "Version": 114
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-east-1::parameter/aws/service/ami-amazon-linux-latest/amzn2-ami-kernel-5.10-hvm-x86_64-ebs",
+        "DataType": "text",
+        "LastModifiedDate": 1721697390.713,
+        "Name": "/aws/service/ami-amazon-linux-latest/amzn2-ami-kernel-5.10-hvm-x86_64-ebs",
+        "Type": "String",
+        "Value": "ami-0dbbc1ffd92e9dc3a",
+        "Version": 73
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-east-1::parameter/aws/service/ami-amazon-linux-latest/amzn2-ami-minimal-hvm-arm64-ebs",
+        "DataType": "text",
+        "LastModifiedDate": 1721697391.321,
+        "Name": "/aws/service/ami-amazon-linux-latest/amzn2-ami-minimal-hvm-arm64-ebs",
+        "Type": "String",
+        "Value": "ami-0f679fed2d6731f5e",
+        "Version": 85
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-east-1::parameter/aws/service/ami-amazon-linux-latest/amzn2-ami-minimal-hvm-x86_64-ebs",
+        "DataType": "text",
+        "LastModifiedDate": 1721697391.614,
+        "Name": "/aws/service/ami-amazon-linux-latest/amzn2-ami-minimal-hvm-x86_64-ebs",
+        "Type": "String",
+        "Value": "ami-00cedd6af9996d4d7",
+        "Version": 114
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-east-1::parameter/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64",
+        "DataType": "text",
+        "LastModifiedDate": 1721692759.694,
+        "Name": "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64",
+        "Type": "String",
+        "Value": "ami-0a5db8fbece0eb74b",
+        "Version": 50
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-east-1::parameter/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64",
+        "DataType": "text",
+        "LastModifiedDate": 1721692760.743,
+        "Name": "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64",
+        "Type": "String",
+        "Value": "ami-0de91fdcfc8d9f74e",
+        "Version": 50
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-east-1::parameter/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-6.1-arm64",
+        "DataType": "text",
+        "LastModifiedDate": 1721692759.96,
+        "Name": "/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-6.1-arm64",
+        "Type": "String",
+        "Value": "ami-0cbbefdbb400bc3fa",
+        "Version": 50
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-east-1::parameter/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-default-x86_64",
+        "DataType": "text",
+        "LastModifiedDate": 1721692761.237,
+        "Name": "/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-default-x86_64",
+        "Type": "String",
+        "Value": "ami-02225bbcc9e4f69ec",
+        "Version": 50
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-east-1::parameter/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-ebs",
+        "DataType": "text",
+        "LastModifiedDate": 1703012167.223,
+        "Name": "/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-ebs",
+        "Type": "String",
+        "Value": "ami-0eabcdae6cabf6e70",
+        "Version": 67
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-east-1::parameter/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-s3",
+        "DataType": "text",
+        "LastModifiedDate": 1703012167.616,
+        "Name": "/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-s3",
+        "Type": "String",
+        "Value": "ami-0654bf9da906daf8b",
+        "Version": 67
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-east-1::parameter/aws/service/ami-amazon-linux-latest/amzn-ami-minimal-hvm-x86_64-ebs",
+        "DataType": "text",
+        "LastModifiedDate": 1703012167.808,
+        "Name": "/aws/service/ami-amazon-linux-latest/amzn-ami-minimal-hvm-x86_64-ebs",
+        "Type": "String",
+        "Value": "ami-0aea210be1a75b94e",
+        "Version": 67
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-east-1::parameter/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2",
+        "DataType": "text",
+        "LastModifiedDate": 1721697390.123,
+        "Name": "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2",
+        "Type": "String",
+        "Value": "ami-01abf14eabdf9aade",
+        "Version": 114
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-east-1::parameter/aws/service/ami-amazon-linux-latest/amzn2-ami-kernel-5.10-hvm-arm64-gp2",
+        "DataType": "text",
+        "LastModifiedDate": 1721697390.421,
+        "Name": "/aws/service/ami-amazon-linux-latest/amzn2-ami-kernel-5.10-hvm-arm64-gp2",
+        "Type": "String",
+        "Value": "ami-0cf49cd7abf721d78",
+        "Version": 73
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-east-1::parameter/aws/service/ami-amazon-linux-latest/amzn2-ami-kernel-5.10-hvm-x86_64-gp2",
+        "DataType": "text",
+        "LastModifiedDate": 1721697391.015,
+        "Name": "/aws/service/ami-amazon-linux-latest/amzn2-ami-kernel-5.10-hvm-x86_64-gp2",
+        "Type": "String",
+        "Value": "ami-0db1e2b6da3a4ef84",
+        "Version": 73
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-east-1::parameter/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-gp2",
+        "DataType": "text",
+        "LastModifiedDate": 1703012167.428,
+        "Name": "/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-gp2",
+        "Type": "String",
+        "Value": "ami-0a80c906edacd0e8b",
+        "Version": 67
+    }
+]

--- a/moto/ssm/resources/ami-amazon-linux-latest/us-gov-west-1.json
+++ b/moto/ssm/resources/ami-amazon-linux-latest/us-gov-west-1.json
@@ -1,0 +1,227 @@
+[
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-west-1::parameter/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-arm64",
+        "DataType": "text",
+        "LastModifiedDate": 1721692762.09,
+        "Name": "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-arm64",
+        "Type": "String",
+        "Value": "ami-011efb3cb2db23315",
+        "Version": 50
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-west-1::parameter/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64",
+        "DataType": "text",
+        "LastModifiedDate": 1721692762.569,
+        "Name": "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64",
+        "Type": "String",
+        "Value": "ami-019ee724f2be51720",
+        "Version": 50
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-west-1::parameter/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-6.1-x86_64",
+        "DataType": "text",
+        "LastModifiedDate": 1721692762.461,
+        "Name": "/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-6.1-x86_64",
+        "Type": "String",
+        "Value": "ami-0c74a4baed89bc2c8",
+        "Version": 50
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-west-1::parameter/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-default-arm64",
+        "DataType": "text",
+        "LastModifiedDate": 1721692762.795,
+        "Name": "/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-default-arm64",
+        "Type": "String",
+        "Value": "ami-01bdd33fcf8c3faaf",
+        "Version": 50
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-west-1::parameter/aws/service/ami-amazon-linux-latest/amzn-ami-minimal-hvm-x86_64-s3",
+        "DataType": "text",
+        "LastModifiedDate": 1703012169.012,
+        "Name": "/aws/service/ami-amazon-linux-latest/amzn-ami-minimal-hvm-x86_64-s3",
+        "Type": "String",
+        "Value": "ami-0bb609de40cb15fb0",
+        "Version": 69
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-west-1::parameter/aws/service/ami-amazon-linux-latest/amzn-ami-pv-x86_64-s3",
+        "DataType": "text",
+        "LastModifiedDate": 1703012169.337,
+        "Name": "/aws/service/ami-amazon-linux-latest/amzn-ami-pv-x86_64-s3",
+        "Type": "String",
+        "Value": "ami-0cdbe7f8dcc75fb7c",
+        "Version": 68
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-west-1::parameter/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-arm64-gp2",
+        "DataType": "text",
+        "LastModifiedDate": 1721697392.494,
+        "Name": "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-arm64-gp2",
+        "Type": "String",
+        "Value": "ami-0fccef3543f16dd9b",
+        "Version": 85
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-west-1::parameter/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-ebs",
+        "DataType": "text",
+        "LastModifiedDate": 1721697392.632,
+        "Name": "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-ebs",
+        "Type": "String",
+        "Value": "ami-0eea2ae1689e53bef",
+        "Version": 119
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-west-1::parameter/aws/service/ami-amazon-linux-latest/amzn2-ami-kernel-5.10-hvm-x86_64-ebs",
+        "DataType": "text",
+        "LastModifiedDate": 1721697392.995,
+        "Name": "/aws/service/ami-amazon-linux-latest/amzn2-ami-kernel-5.10-hvm-x86_64-ebs",
+        "Type": "String",
+        "Value": "ami-06ba9aacc2eed0ff5",
+        "Version": 74
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-west-1::parameter/aws/service/ami-amazon-linux-latest/amzn2-ami-minimal-hvm-arm64-ebs",
+        "DataType": "text",
+        "LastModifiedDate": 1721697393.216,
+        "Name": "/aws/service/ami-amazon-linux-latest/amzn2-ami-minimal-hvm-arm64-ebs",
+        "Type": "String",
+        "Value": "ami-0549b0e03a35cad47",
+        "Version": 85
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-west-1::parameter/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-default-x86_64",
+        "DataType": "text",
+        "LastModifiedDate": 1721692762.894,
+        "Name": "/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-default-x86_64",
+        "Type": "String",
+        "Value": "ami-03e7ac6ecae00de4c",
+        "Version": 50
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-west-1::parameter/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-ebs",
+        "DataType": "text",
+        "LastModifiedDate": 1703012168.667,
+        "Name": "/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-ebs",
+        "Type": "String",
+        "Value": "ami-034c73ffbb74bb99c",
+        "Version": 69
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-west-1::parameter/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-s3",
+        "DataType": "text",
+        "LastModifiedDate": 1703012168.841,
+        "Name": "/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-s3",
+        "Type": "String",
+        "Value": "ami-08cdd8d24cc1709c7",
+        "Version": 69
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-west-1::parameter/aws/service/ami-amazon-linux-latest/amzn-ami-minimal-hvm-x86_64-ebs",
+        "DataType": "text",
+        "LastModifiedDate": 1703012168.934,
+        "Name": "/aws/service/ami-amazon-linux-latest/amzn-ami-minimal-hvm-x86_64-ebs",
+        "Type": "String",
+        "Value": "ami-00eea1719b6aae09e",
+        "Version": 69
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-west-1::parameter/aws/service/ami-amazon-linux-latest/amzn-ami-minimal-pv-x86_64-ebs",
+        "DataType": "text",
+        "LastModifiedDate": 1703012169.106,
+        "Name": "/aws/service/ami-amazon-linux-latest/amzn-ami-minimal-pv-x86_64-ebs",
+        "Type": "String",
+        "Value": "ami-0e3c8ed0bf77adcff",
+        "Version": 68
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-west-1::parameter/aws/service/ami-amazon-linux-latest/amzn-ami-minimal-pv-x86_64-s3",
+        "DataType": "text",
+        "LastModifiedDate": 1703012169.187,
+        "Name": "/aws/service/ami-amazon-linux-latest/amzn-ami-minimal-pv-x86_64-s3",
+        "Type": "String",
+        "Value": "ami-07aeb19a8d919da02",
+        "Version": 68
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-west-1::parameter/aws/service/ami-amazon-linux-latest/amzn-ami-pv-x86_64-ebs",
+        "DataType": "text",
+        "LastModifiedDate": 1703012169.262,
+        "Name": "/aws/service/ami-amazon-linux-latest/amzn-ami-pv-x86_64-ebs",
+        "Type": "String",
+        "Value": "ami-0eb0af607aabfafff",
+        "Version": 68
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-west-1::parameter/aws/service/ami-amazon-linux-latest/amzn2-ami-kernel-5.10-hvm-arm64-gp2",
+        "DataType": "text",
+        "LastModifiedDate": 1721697392.88,
+        "Name": "/aws/service/ami-amazon-linux-latest/amzn2-ami-kernel-5.10-hvm-arm64-gp2",
+        "Type": "String",
+        "Value": "ami-0c2ed33fcbcc83ebe",
+        "Version": 74
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-west-1::parameter/aws/service/ami-amazon-linux-latest/amzn2-ami-kernel-5.10-hvm-x86_64-gp2",
+        "DataType": "text",
+        "LastModifiedDate": 1721697393.114,
+        "Name": "/aws/service/ami-amazon-linux-latest/amzn2-ami-kernel-5.10-hvm-x86_64-gp2",
+        "Type": "String",
+        "Value": "ami-0e7f6bd7808f3f95f",
+        "Version": 74
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-west-1::parameter/aws/service/ami-amazon-linux-latest/amzn2-ami-minimal-hvm-x86_64-ebs",
+        "DataType": "text",
+        "LastModifiedDate": 1721697393.321,
+        "Name": "/aws/service/ami-amazon-linux-latest/amzn2-ami-minimal-hvm-x86_64-ebs",
+        "Type": "String",
+        "Value": "ami-05eb4d4349faed35c",
+        "Version": 119
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-west-1::parameter/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64",
+        "DataType": "text",
+        "LastModifiedDate": 1721692762.216,
+        "Name": "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64",
+        "Type": "String",
+        "Value": "ami-0813aacedccabaaad",
+        "Version": 50
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-west-1::parameter/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64",
+        "DataType": "text",
+        "LastModifiedDate": 1721692762.685,
+        "Name": "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64",
+        "Type": "String",
+        "Value": "ami-0f8c631fccd898fcc",
+        "Version": 50
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-west-1::parameter/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-6.1-arm64",
+        "DataType": "text",
+        "LastModifiedDate": 1721692762.348,
+        "Name": "/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-6.1-arm64",
+        "Type": "String",
+        "Value": "ami-0b2a6da8cb6b500ff",
+        "Version": 50
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-west-1::parameter/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-gp2",
+        "DataType": "text",
+        "LastModifiedDate": 1703012168.758,
+        "Name": "/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-gp2",
+        "Type": "String",
+        "Value": "ami-0cfb8ee4baf66e51e",
+        "Version": 69
+    },
+    {
+        "ARN": "arn:aws-us-gov:ssm:us-gov-west-1::parameter/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2",
+        "DataType": "text",
+        "LastModifiedDate": 1721697392.767,
+        "Name": "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2",
+        "Type": "String",
+        "Value": "ami-03ebdb8bd059274a1",
+        "Version": 119
+    }
+]

--- a/tests/test_ssm/test_ssm_default_amis.py
+++ b/tests/test_ssm/test_ssm_default_amis.py
@@ -1,4 +1,5 @@
 import boto3
+import pytest
 
 from moto import mock_aws
 
@@ -6,8 +7,16 @@ test_ami = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_6
 
 
 @mock_aws
-def test_ssm_get_latest_ami_by_path():
-    client = boto3.client("ssm", region_name="us-west-1")
+@pytest.mark.parametrize(
+    "partition,region",
+    [
+        ("aws", "us-west-1"),
+        ("aws-us-gov", "us-gov-east-1"),
+        ("aws-us-gov", "us-gov-west-1"),
+    ],
+)
+def test_ssm_get_latest_ami_by_path(partition, region):
+    client = boto3.client("ssm", region_name=region)
     path = "/aws/service/ami-amazon-linux-latest"
     params = client.get_parameters_by_path(Path=path)["Parameters"]
     assert len(params) == 10
@@ -17,7 +26,7 @@ def test_ssm_get_latest_ami_by_path():
     )
     assert all({p["Type"] == "String" for p in params})
     assert all({p["DataType"] == "text" for p in params})
-    assert all({p["ARN"].startswith("arn:aws:ssm:us-west-1") for p in params})
+    assert all({p["ARN"].startswith(f"arn:{partition}:ssm:{region}") for p in params})
 
 
 @mock_aws

--- a/tests/test_ssm/test_ssm_parameterstore.py
+++ b/tests/test_ssm/test_ssm_parameterstore.py
@@ -1,3 +1,5 @@
+import pytest
+
 from moto.ssm.models import ParameterDict
 
 
@@ -83,3 +85,17 @@ def test_ssm_parameter_from_unknown_region():
             "/aws/service/ami-amazon-linux-latest", recursive=False
         )
     )
+
+
+@pytest.mark.parametrize("region", ["us-gov-east-1", "us-gov-west-1"])
+def test_ssm_parameter_from_gov_cloud_east_region(region):
+    store = ParameterDict("000000000000", region)
+    keys = list(
+        store.get_keys_beginning_with(
+            "/aws/service/ami-amazon-linux-latest", recursive=False
+        )
+    )
+    for key in keys:
+        ssm_parameter = store.get(key)[0]
+        ami = ssm_parameter.value
+        assert ami.startswith("ami-")


### PR DESCRIPTION
This PR adds the SSM AWS Linux resources available in two not publicly available gov cloud regions - us-gov-east-1 and us-gov-west-1.

The data was provided by a customer who preferred not to share the original AMI values; hence, these values are randomly generated and differ from the official AWS values.

This PR was originally proposed to moto origin, but due to automatic update concerns not accepted: https://github.com/getmoto/moto/pull/8006