### PR TITLE
add CI workflow to sync, build, publish, release moto-ext

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
           # Configure git
           git config --global user.name 'LocalStack Bot'
           git config --global user.email 'localstack-bot@users.noreply.github.com'
+          git remote set-url origin https://git:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
           
           # make sure to switch to the `localstack` branch (default / main branch of this fork)
           git switch localstack
@@ -68,8 +69,8 @@ jobs:
           KEYS=("name" "url")
           
           # Read files into arrays
-          mapfile -t LOCAL_LINES < "$remote"
-          mapfile -t REMOTE_LINES < "$local"
+          mapfile -t REMOTE_LINES < "$remote"
+          mapfile -t LOCAL_LINES < "$local"
           
           echo "merging $local + $local + $remote ..."
           
@@ -83,11 +84,11 @@ jobs:
           }
           
           # Build result: keep key-matched lines from local, others from remote
-          for i in "${!REMOTE_LINES[@]}"; do
-            if keep_line "${LOCAL_LINES[i]}"; then
-              echo "${LOCAL_LINES[i]}"
-            else
+          for i in "${!LOCAL_LINES[@]}"; do
+            if keep_line "${REMOTE_LINES[i]}"; then
               echo "${REMOTE_LINES[i]}"
+            else
+              echo "${LOCAL_LINES[i]}"
             fi
           done > "$local"
           
@@ -178,3 +179,5 @@ jobs:
           # git push --force-with-lease
           # git push --atomic origin localstack $NEW_VERSION
           # gh release create $NEW_VERSION
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@
 name: Sync / Release moto-ext
 
 on:
-  # TODO replace this push trigger with a schedule (every Monday morning)
-  push:
+  schedule:
+    - cron: 0 5 * * MON
   workflow_dispatch:
     inputs:
       dry_run:
@@ -178,6 +178,8 @@ jobs:
         run: |
           git push --force-with-lease
           git push --atomic origin localstack $NEW_VERSION
-          gh release create $NEW_VERSION
+          # Wait a few seconds to avoid "gh release create" fail because the tag is not yet available
+          sleep 10
+          gh release create $NEW_VERSION --notes "automatic rebase sync and release"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,23 +43,80 @@ jobs:
         with:
           python-version: '3.13'
 
-      - name: Rebase localstack branch with latest master from upstream
-        run: |
+      - name: Configure Git
+        run: | 
           # Configure git
           git config --global user.name 'LocalStack Bot'
           git config --global user.email 'localstack-bot@users.noreply.github.com'
-
+          
           # make sure to switch to the `localstack` branch (default / main branch of this fork)
           git switch localstack
           # add moto upstream as remote
           git remote add upstream https://github.com/getmoto/moto.git
           # rebase with latest changes
           git pull
+          
+          # Create a custom merge driver which prefers everything from upstream _BUT_ the name and the URL
+          mkdir -p $HOME/.local/bin
+          cat > $HOME/.local/bin/git-prefer-theirs-name-url << EOF
+          #!/bin/bash
+          base="$1"
+          local="$2"
+          remote="$3"
+          
+          # Define keys to keep
+          KEYS=("name" "url")
+          
+          # Read files into arrays
+          mapfile -t LOCAL_LINES < "$remote"
+          mapfile -t REMOTE_LINES < "$local"
+          
+          echo "merging $local + $local + $remote ..."
+          
+          # Function to check if a line should be kept (matches any key)
+          keep_line() {
+            local line="$1"
+            for key in "${KEYS[@]}"; do
+              [[ "$line" == *"$key"* ]] && return 0
+            done
+            return 1
+          }
+          
+          # Build result: keep key-matched lines from local, others from remote
+          for i in "${!REMOTE_LINES[@]}"; do
+            if keep_line "${LOCAL_LINES[i]}"; then
+              echo "${LOCAL_LINES[i]}"
+            else
+              echo "${REMOTE_LINES[i]}"
+            fi
+          done > "$local"
+          
+          exit 0
+          EOF
+          
+          # make the script executable and add it to the PATH
+          chmod +x $HOME/.local/bin/git-prefer-theirs-name-url
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          
+          # add the merge driver to the git config
+          cat >> .git/config << EOF
+          
+          [merge "git-prefer-theirs-name-url"]
+                name = A driver which resolves merge conflicts on a setup.cfg such that it always takes the local name and url, and everything else from upstream
+                driver = git-prefer-theirs-name-url %O %A %B
+          EOF
+          
+          # define to use the custom merge driver for the setup.cfg
+          cat > .gitattributes << EOF
+          setup.cfg   merge=git-prefer-theirs-name-url
+          EOF
+          
+          
+
+      - name: Rebase localstack branch with latest master from upstream
+        run: |
           git fetch upstream
-          # TODO make this less dangerous:
-          #  - Use a custom merge driver which prefers everything from upstream _BUT_ the name and the URL
-          #  - Set a .gitattributes file to only use this merge driver for setup.cfg
-          git rebase -Xtheirs upstream/master
+          git rebase upstream/master
 
       - name: Determine new version
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,123 @@
+# LocalStack specific workflow to implement a fully-integrated continuous integration pipeline for our fork
+# - Rebase this fork based on the latest commit on `main` of upstream
+# - Build a Python source and wheel distribution of moto-ext with deterministic versioning
+# - Publish the distributions to PyPi
+# - Tag the commit in this fork with the new version
+# - Create a GitHub release for the new version
+
+name: Sync / Release moto-ext
+
+on:
+  # TODO remove this trigger after testing
+  push:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry Run?'
+        default: true
+        required: true
+        type: boolean
+
+# limit concurrency to 1
+concurrency:
+  group: ${{ github.workflow }}
+
+permissions:
+  contents: write
+
+jobs:
+  sync-build-release-moto-ext:
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/moto-ext/
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: localstack
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Rebase localstack branch with latest master from upstream
+        run: |
+          # Configure git
+          git config --global user.name 'LocalStack Bot'
+          git config --global user.email 'localstack-bot@users.noreply.github.com'
+
+          # make sure to switch to the `localstack` branch (default / main branch of this fork)
+          git switch localstack
+          # add moto upstream as remote
+          git remote add upstream https://github.com/getmoto/moto.git
+          # rebase with latest changes
+          git pull
+          git fetch upstream
+          # TODO make this less dangerous:
+          #  - Use a custom merge driver which prefers everything from upstream _BUT_ the name and the URL
+          #  - Set a .gitattributes file to only use this merge driver for setup.cfg
+          git rebase -Xtheirs upstream/master
+
+      - name: Determine new version
+        run: |
+          echo "Determining new version..."
+          cat > setuptools.cfg << EOF
+          [tool.setuptools_scm]
+          local_scheme = "no-local-version"
+          version_scheme = "post-release"
+          EOF
+          python3 -m venv .venv
+          source .venv/bin/activate
+          python3 -m pip install setuptools_scm
+          NEW_VERSION=$(python3 -m setuptools_scm -c setuptools.cfg)
+          NEW_VERSION="${NEW_VERSION//dev/post}"
+          echo "New version is: $NEW_VERSION"
+          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+
+      - name: Build Python distributions
+        # FYI: Checks in this script only work because the -e flag is enabled by default in GitHub actions
+        run: |
+          python3 -m pip install build
+          
+          echo "Setting new version in setup.cfg":
+          # make sure setup.cfg is not dirty yet
+          git diff --exit-code setup.cfg
+          sed -i -E 's/^(version\s*=\s*)("?)[^"]+("?)/\1\2'"$NEW_VERSION"'\3/' setup.cfg
+          # make sure setup.cfg is dirty now
+          ! git diff --exit-code setup.cfg
+          
+          echo "Building new version and tagging commit..."
+          python3 -m build
+
+      - name: Tag successful build
+        run: |
+          git tag -a $NEW_VERSION -m $NEW_VERSION
+
+      - name: Clean up
+        run: |
+          git reset --hard
+          git clean -df
+
+      - name: Store built distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: moto-ext-dists
+          path: dist/*.*
+
+      # publish the package before pushing the tag (this might fail if the version already exists on PyPI)
+      - name: Publish package distributions to PyPI
+        if: ${{ github.event.inputs.dry_run == false }}
+        run: |
+          echo "Ensure that this is really only triggered if dry run is explicitly set to false"
+        # uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Push & Create Release
+        if: ${{ github.event.inputs.dry_run == false }}
+        run: |
+          echo "Ensure that this is really only triggered if dry run is explicitly set to false"
+          # git push --force-with-lease
+          # git push --atomic origin localstack $NEW_VERSION
+          # gh release create $NEW_VERSION

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,15 +22,15 @@ on:
 concurrency:
   group: ${{ github.workflow }}
 
-permissions:
-  contents: write
-
 jobs:
   sync-build-release-moto-ext:
     runs-on: ubuntu-latest
     environment:
       name: pypi
       url: https://pypi.org/project/moto-ext/
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: localstack
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -48,7 +49,7 @@ jobs:
           # Configure git
           git config --global user.name 'LocalStack Bot'
           git config --global user.email 'localstack-bot@users.noreply.github.com'
-          git remote set-url origin https://git:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git remote set-url origin https://git:${{ secrets.PRO_ACCESS_TOKEN }}@github.com/${{ github.repository }}
           
           # make sure to switch to the `localstack` branch (default / main branch of this fork)
           git switch localstack
@@ -61,36 +62,40 @@ jobs:
           mkdir -p $HOME/.local/bin
           cat > $HOME/.local/bin/git-prefer-theirs-name-url << EOF
           #!/bin/bash
-          base="$1"
-          local="$2"
-          remote="$3"
+          set -e
+          
+          base="\$1"
+          local="\$2"
+          remote="\$3"
+          
+          echo "Executing custom merge driver for base \$base, local \$local, remote \$remote."
           
           # Define keys to keep
           KEYS=("name" "url")
           
           # Read files into arrays
-          mapfile -t REMOTE_LINES < "$remote"
-          mapfile -t LOCAL_LINES < "$local"
+          mapfile -t REMOTE_LINES < "\$remote"
+          mapfile -t LOCAL_LINES < "\$local"
           
-          echo "merging $local + $local + $remote ..."
+          echo "merging \$local + \$local + \$remote ..."
           
           # Function to check if a line should be kept (matches any key)
           keep_line() {
-            local line="$1"
-            for key in "${KEYS[@]}"; do
-              [[ "$line" == *"$key"* ]] && return 0
+            local line="\$1"
+            for key in "\${KEYS[@]}"; do
+              [[ "\$line" == *"\$key"* ]] && return 0
             done
             return 1
           }
           
-          # Build result: keep key-matched lines from local, others from remote
-          for i in "${!LOCAL_LINES[@]}"; do
-            if keep_line "${REMOTE_LINES[i]}"; then
-              echo "${REMOTE_LINES[i]}"
+          # keep key-matched lines from local, others from remote
+          for i in "\${!LOCAL_LINES[@]}"; do
+            if keep_line "\${REMOTE_LINES[i]}"; then
+              echo "\${REMOTE_LINES[i]}"
             else
-              echo "${LOCAL_LINES[i]}"
+              echo "\${LOCAL_LINES[i]}"
             fi
-          done > "$local"
+          done > "\$local"
           
           exit 0
           EOF
@@ -103,13 +108,13 @@ jobs:
           cat >> .git/config << EOF
           
           [merge "git-prefer-theirs-name-url"]
-                name = A driver which resolves merge conflicts on a setup.cfg such that it always takes the local name and url, and everything else from upstream
-                driver = git-prefer-theirs-name-url %O %A %B
+                  name = A driver which resolves merge conflicts on a setup.cfg such that it always takes the local name and url, and everything else from upstream
+                  driver = git-prefer-theirs-name-url %O %A %B
           EOF
           
           # define to use the custom merge driver for the setup.cfg
           cat > .gitattributes << EOF
-          setup.cfg   merge=git-prefer-theirs-name-url
+          setup.cfg       merge=git-prefer-theirs-name-url
           EOF
 
       - name: Rebase localstack branch with latest master from upstream

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@
 name: Sync / Release moto-ext
 
 on:
-  # TODO remove this trigger after testing
+  # TODO replace this push trigger with a schedule (every Monday morning)
   push:
   workflow_dispatch:
     inputs:
@@ -111,8 +111,6 @@ jobs:
           cat > .gitattributes << EOF
           setup.cfg   merge=git-prefer-theirs-name-url
           EOF
-          
-          
 
       - name: Rebase localstack branch with latest master from upstream
         run: |
@@ -168,16 +166,13 @@ jobs:
       # publish the package before pushing the tag (this might fail if the version already exists on PyPI)
       - name: Publish package distributions to PyPI
         if: ${{ github.event.inputs.dry_run == false }}
-        run: |
-          echo "Ensure that this is really only triggered if dry run is explicitly set to false"
-        # uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Push & Create Release
         if: ${{ github.event.inputs.dry_run == false }}
         run: |
-          echo "Ensure that this is really only triggered if dry run is explicitly set to false"
-          # git push --force-with-lease
-          # git push --atomic origin localstack $NEW_VERSION
-          # gh release create $NEW_VERSION
+          git push --force-with-lease
+          git push --atomic origin localstack $NEW_VERSION
+          gh release create $NEW_VERSION
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Motivation
In order to streamline upgrades of this fork with the upstream repo ([`getmoto/moto`](https://github.com/getmoto/moto)), and in order to implement proper continuous integration of `moto(-ext)` in `localstack/localstack`, we want to:
1. Automate the whole sync and release process of this repo.
2. Automate the update of `moto-ext` in `localstack/localstack`.

This PR tackles (1).

## Changes
- Add a new workflow which:
  1. Syncs (rebases) the `localstack` branch of this repo with the `master` branch of the upstream repo (`getmoto/moto`).
  2. Introduces a new deterministic versioning scheme by using `setuptools_scm` (based on the distance to the latest tag).
    - This means that there could _potentially_ be a conflict / a smaller version if there are no changes upstream and we remove a commit in our fork. But this is very unlikely.
  3. Build the distributions with this new version.
  4. Tag the result.
  5. Push the distributions to PyPi.
  6. Push the commit and the tag and create a new release in the GitHub repo.

## ToDo
- [x] Figure out how to perform a clean rebase with https://github.com/localstack/moto/commit/d901045ae7ff5100ddfc8d260e5927146bcda315 (which is problematic with upstream changes to [the version](https://github.com/getmoto/moto/blob/609d897f254b3b93b584d3a92e124b39c0a317f9/setup.cfg#L3) (hopefully without writing a customer git merge driver 😅)
  - A merge driver it is...
- [x] Testing
- [x] Remove this branch from the list of branches which are allowed to use the `pypi` environment.

/cc @viren-nadkarni 