### PR TITLE
add retry for GH release creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,13 +173,19 @@ jobs:
         if: ${{ github.event.inputs.dry_run == false }}
         uses: pypa/gh-action-pypi-publish@release/v1
 
-      - name: Push & Create Release
+      - name: Push
         if: ${{ github.event.inputs.dry_run == false }}
         run: |
           git push --force-with-lease
           git push --atomic origin localstack $NEW_VERSION
-          # Wait a few seconds to avoid "gh release create" fail because the tag is not yet available
-          sleep 10
-          gh release create $NEW_VERSION --notes "automatic rebase sync and release"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Add a retry to avoid issues where the GH CLI fails
+      # because it does not yet detect the pushed tag.
+      - name: Create Release
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 5
+          retry_wait_seconds: 120
+          command: gh release create $NEW_VERSION --notes "automatic rebase sync and release"


### PR DESCRIPTION
## Motivation
Last week we added a CI workflow to automatically sync and release this fork for us (see https://github.com/localstack/moto/pull/78).
Unfortunately, one step is still not stable: The actual creation of the release on GitHub. While this is optional, it would be nice to have the release properly being shown in the UI.
[The step fails with the following error](https://github.com/localstack/moto/actions/runs/17905066418):
```
To https://github.com/localstack/moto
 + 662f5b948...8e3016550 localstack -> localstack (forced update)
To https://github.com/localstack/moto
 * [new tag]             5.1.13.post7 -> 5.1.13.post7
tag 5.1.13.post7 exists locally but has not been pushed to getmoto/moto, please push it before continuing or specify the `--target` flag to create a new tag
Error: Process completed with exit code 1.
```
The logs clearly show that the tag is pushed, but is not recognized by GitHub right afterwards.
This PR tries to address this issue by wrapping the release creation into a "retry" action.

## Changes
- Wrap the creation of the release on GitHub into a "retry" action