### PR TITLE
Remove aws-sam-translator pin for Python<3.14

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,8 @@ moto = py.typed
 [options.extras_require]
 all =
     antlr4-python3-runtime
-	aws-sam-translator<=1.103.0
+    aws-sam-translator<=1.103.0; python_version >= "3.14"
+    aws-sam-translator>=1.105.0; python_version < "3.14"
     joserfc>=0.9.0
     jsonpath_ng
     docker>=3.0.0
@@ -63,7 +64,8 @@ all =
     multipart
 proxy =
     antlr4-python3-runtime
-	aws-sam-translator<=1.103.0
+    aws-sam-translator<=1.103.0; python_version >= "3.14"
+    aws-sam-translator>=1.105.0; python_version < "3.14"
     joserfc>=0.9.0
     jsonpath_ng
     docker>=2.5.1
@@ -79,7 +81,8 @@ proxy =
     multipart
 server =
     antlr4-python3-runtime
-	aws-sam-translator<=1.103.0
+    aws-sam-translator<=1.103.0; python_version >= "3.14"
+    aws-sam-translator>=1.105.0; python_version < "3.14"
     joserfc>=0.9.0
     jsonpath_ng
     docker>=3.0.0


### PR DESCRIPTION
Upstream moto introduced a pin to `aws-sam-translator` because the latest version `1.105.0` does not support Python 3.14. However, we need `1.105.0` because it contains the Lambda Managed Instances support. 

Because we don't use Python 3.14, we can introduce a separate dependency that allows `1.105.0` for versions below Python 3.14. 