### PR TITLE
Force rebase on sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           python-version: '3.13'
 
       - name: Configure Git
-        run: | 
+        run: |
           # Configure git
           git config --global user.name 'LocalStack Bot'
           git config --global user.email 'localstack-bot@users.noreply.github.com'
@@ -120,7 +120,7 @@ jobs:
       - name: Rebase localstack branch with latest master from upstream
         run: |
           git fetch upstream
-          git rebase upstream/master
+          git rebase -f upstream/master
 
       - name: Determine new version
         run: |


### PR DESCRIPTION
The current version of the Sync & Release action does not work when there are no upstream changes between our latest post release and now. 
The reason for that is that the rebase is skipped in case `upstream/master` contains no changes compared to what we have in this fork. However, that rebase is necessary to get rid of the latest `postXY` release in the current tree. A rebase would replace it with new commits based on the new upstream. If it's still there `setuptools_scm` will consider it the latest version tag and then build the new post release based off of it, so `postXY.post1`. 

To avoid this, we can force the rebase to always happen, even if there were no changes upstream.