### PR TITLE
Enable static data update actions

### DIFF
--- a/.github/workflows/data-update_config-managed-rules.yml
+++ b/.github/workflows/data-update_config-managed-rules.yml
@@ -16,7 +16,7 @@ jobs:
   update:
     name: Update Config Managed Rules
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/master' && github.repository == 'getmoto/moto' }}
+    if: ${{ github.ref == 'refs/heads/localstack' && github.repository == 'localstack/moto' }}
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/data-update_ec2-instance-offerings.yml
+++ b/.github/workflows/data-update_ec2-instance-offerings.yml
@@ -16,7 +16,7 @@ jobs:
   update:
     name: Update EC2 Instance Offerings
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/master' && github.repository == 'getmoto/moto' }}
+    if: ${{ github.ref == 'refs/heads/localstack' && github.repository == 'localstack/moto' }}
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/data-update_ec2-instance-offerings.yml
+++ b/.github/workflows/data-update_ec2-instance-offerings.yml
@@ -35,7 +35,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v5
       with:
         aws-region: us-east-1
-        role-to-assume: arn:aws:iam::623948600419:role/MotoExt-CI-Role
+        role-to-assume: arn:aws:iam::385386232812:role/MotoExt-OIDC-Role
 
     - name: Pull EC2 instance types from AWS
       run: |

--- a/.github/workflows/data-update_ec2-instance-offerings.yml
+++ b/.github/workflows/data-update_ec2-instance-offerings.yml
@@ -35,7 +35,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v5
       with:
         aws-region: us-east-1
-        role-to-assume: arn:aws:iam::682283128318:role/GithubActionsRole
+        role-to-assume: arn:aws:iam::623948600419:role/MotoExt-CI-Role
 
     - name: Pull EC2 instance types from AWS
       run: |

--- a/.github/workflows/data-update_ec2-instance-types.yml
+++ b/.github/workflows/data-update_ec2-instance-types.yml
@@ -16,7 +16,7 @@ jobs:
   update:
     name: Update EC2 Instance Types
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/master' && github.repository == 'getmoto/moto' }}
+    if: ${{ github.ref == 'refs/heads/localstack' && github.repository == 'localstack/moto' }}
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/data-update_ec2-instance-types.yml
+++ b/.github/workflows/data-update_ec2-instance-types.yml
@@ -35,7 +35,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v5
       with:
         aws-region: us-east-1
-        role-to-assume: arn:aws:iam::623948600419:role/MotoExt-CI-Role
+        role-to-assume: arn:aws:iam::385386232812:role/MotoExt-OIDC-Role
 
     - name: Pull EC2 instance types from AWS
       run: |

--- a/.github/workflows/data-update_ec2-instance-types.yml
+++ b/.github/workflows/data-update_ec2-instance-types.yml
@@ -35,7 +35,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v5
       with:
         aws-region: us-east-1
-        role-to-assume: arn:aws:iam::682283128318:role/GithubActionsRole
+        role-to-assume: arn:aws:iam::623948600419:role/MotoExt-CI-Role
 
     - name: Pull EC2 instance types from AWS
       run: |

--- a/.github/workflows/data-update_emr_instance_types.yml
+++ b/.github/workflows/data-update_emr_instance_types.yml
@@ -16,7 +16,7 @@ jobs:
   update:
     name: Update EMR Instance Types
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/master' && github.repository == 'getmoto/moto' }}
+    if: ${{ github.ref == 'refs/heads/localstack' && github.repository == 'localstack/moto' }}
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/data-update_emr_instance_types.yml
+++ b/.github/workflows/data-update_emr_instance_types.yml
@@ -35,7 +35,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v5
       with:
         aws-region: us-east-1
-        role-to-assume: arn:aws:iam::682283128318:role/GithubActionsRole
+        role-to-assume: arn:aws:iam::623948600419:role/MotoExt-CI-Role
 
     - name: Pull EMR instance types from AWS
       run: |

--- a/.github/workflows/data-update_emr_instance_types.yml
+++ b/.github/workflows/data-update_emr_instance_types.yml
@@ -35,7 +35,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v5
       with:
         aws-region: us-east-1
-        role-to-assume: arn:aws:iam::623948600419:role/MotoExt-CI-Role
+        role-to-assume: arn:aws:iam::385386232812:role/MotoExt-OIDC-Role
 
     - name: Pull EMR instance types from AWS
       run: |

--- a/.github/workflows/data-update_iam-managed-policies.yml
+++ b/.github/workflows/data-update_iam-managed-policies.yml
@@ -16,7 +16,7 @@ jobs:
   update:
     name: Update IAM Managed Policies
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/master' && github.repository == 'getmoto/moto' }}
+    if: ${{ github.ref == 'refs/heads/localstack' && github.repository == 'localstack/moto' }}
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/data-update_iam-managed-policies.yml
+++ b/.github/workflows/data-update_iam-managed-policies.yml
@@ -35,7 +35,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v5
       with:
         aws-region: us-east-1
-        role-to-assume: arn:aws:iam::623948600419:role/MotoExt-CI-Role
+        role-to-assume: arn:aws:iam::385386232812:role/MotoExt-OIDC-Role
 
     - name: Pull IAM managed policies from AWS
       run: |

--- a/.github/workflows/data-update_iam-managed-policies.yml
+++ b/.github/workflows/data-update_iam-managed-policies.yml
@@ -35,7 +35,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v5
       with:
         aws-region: us-east-1
-        role-to-assume: arn:aws:iam::682283128318:role/GithubActionsRole
+        role-to-assume: arn:aws:iam::623948600419:role/MotoExt-CI-Role
 
     - name: Pull IAM managed policies from AWS
       run: |

--- a/.github/workflows/data-update_ssm-default-amis.yml
+++ b/.github/workflows/data-update_ssm-default-amis.yml
@@ -16,7 +16,7 @@ jobs:
   update:
     name: Update SSM default AMIs
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/master' && github.repository == 'getmoto/moto' }}
+    if: ${{ github.ref == 'refs/heads/localstack' && github.repository == 'localstack/moto' }}
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/data-update_ssm-default-amis.yml
+++ b/.github/workflows/data-update_ssm-default-amis.yml
@@ -35,7 +35,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v5
       with:
         aws-region: us-east-1
-        role-to-assume: arn:aws:iam::623948600419:role/MotoExt-CI-Role
+        role-to-assume: arn:aws:iam::385386232812:role/MotoExt-OIDC-Role
 
     - name: Pull SSM default AMIs from AWS
       run: |

--- a/.github/workflows/data-update_ssm-default-amis.yml
+++ b/.github/workflows/data-update_ssm-default-amis.yml
@@ -35,7 +35,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v5
       with:
         aws-region: us-east-1
-        role-to-assume: arn:aws:iam::682283128318:role/GithubActionsRole
+        role-to-assume: arn:aws:iam::623948600419:role/MotoExt-CI-Role
 
     - name: Pull SSM default AMIs from AWS
       run: |

--- a/.github/workflows/data-update_ssm-default-parameters.yml
+++ b/.github/workflows/data-update_ssm-default-parameters.yml
@@ -16,7 +16,7 @@ jobs:
   update:
     name: Update SSM default parameters
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/master' && github.repository == 'getmoto/moto' }}
+    if: ${{ github.ref == 'refs/heads/localstack' && github.repository == 'localstack/moto' }}
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/data-update_ssm-default-parameters.yml
+++ b/.github/workflows/data-update_ssm-default-parameters.yml
@@ -35,7 +35,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v5
       with:
         aws-region: us-east-1
-        role-to-assume: arn:aws:iam::623948600419:role/MotoExt-CI-Rol
+        role-to-assume: arn:aws:iam::385386232812:role/MotoExt-OIDC-Role
 
     - name: Pull SSM default Parameters from AWS
       run: |

--- a/.github/workflows/data-update_ssm-default-parameters.yml
+++ b/.github/workflows/data-update_ssm-default-parameters.yml
@@ -35,7 +35,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v5
       with:
         aws-region: us-east-1
-        role-to-assume: arn:aws:iam::682283128318:role/GithubActionsRole
+        role-to-assume: arn:aws:iam::623948600419:role/MotoExt-CI-Rol
 
     - name: Pull SSM default Parameters from AWS
       run: |

--- a/.github/workflows/data-update_ssm-optimized-amis.yml
+++ b/.github/workflows/data-update_ssm-optimized-amis.yml
@@ -16,7 +16,7 @@ jobs:
   update:
     name: Update SSM Optimized AMIs
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/master' && github.repository == 'getmoto/moto' }}
+    if: ${{ github.ref == 'refs/heads/localstack' && github.repository == 'localstack/moto' }}
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/data-update_ssm-optimized-amis.yml
+++ b/.github/workflows/data-update_ssm-optimized-amis.yml
@@ -35,7 +35,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v5
       with:
         aws-region: us-east-1
-        role-to-assume: arn:aws:iam::682283128318:role/GithubActionsRole
+        role-to-assume: arn:aws:iam::623948600419:role/MotoExt-CI-Role
 
     - name: Pull SSM Optimized AMIs from AWS
       run: |

--- a/.github/workflows/data-update_ssm-optimized-amis.yml
+++ b/.github/workflows/data-update_ssm-optimized-amis.yml
@@ -35,7 +35,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v5
       with:
         aws-region: us-east-1
-        role-to-assume: arn:aws:iam::623948600419:role/MotoExt-CI-Role
+        role-to-assume: arn:aws:iam::385386232812:role/MotoExt-OIDC-Role
 
     - name: Pull SSM Optimized AMIs from AWS
       run: |


### PR DESCRIPTION
## Changes

This PR enables the static data update CI actions. These actions run on upstream Moto repo and regularly fetch static data like:

- SSM
  - Optimised AMIs
  - Default parameters
  - Default AMIs
- IAM
  - Managed policies
- EMR
  - Instance types
- EC2
  - Instance types
  - Instance offerings
- Config
  - Managed rules

Scoped AWS credentials are fetched in each workflow using [GH OIDC](https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-aws).

## Tests

Test run: https://github.com/localstack/moto/actions/runs/21508101234/job/61968482244 and [created PR](https://github.com/localstack/moto/pull/87) 

## Related

Closes: PNX-557