### PR TITLE
Add step to configure Git in release action

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -108,6 +108,13 @@ jobs:
           echo "Building distributions"
           python3 -m build
 
+      - name: Configure Git
+        run: |
+          git config --global user.name 'LocalStack Bot'
+          git config --global user.email 'localstack-bot@users.noreply.github.com'
+          git remote set-url origin https://git:${{ secrets.PRO_ACCESS_TOKEN }}@github.com/${{ github.repository }}
+          git switch localstack
+
       - name: Create and push tag
         env:
           NEW_VERSION: ${{ steps.semver.outputs.patch }}


### PR DESCRIPTION
The last automated trigger of the release action [failed](https://github.com/localstack/moto/actions/runs/21813642337) because Git wasn't properly configured.

This PR adds the missing step, which were previously present in the [unified rebase action](https://github.com/localstack/moto/pull/78/changes#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR49) but somehow got dropped during the rework.