### PR TITLE
Pin cfn-lint conditionally based on python_version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,8 @@ all =
     docker>=3.0.0
     graphql-core
     PyYAML>=5.1
-    cfn-lint>=0.40.0,<=1.41.0
+    cfn-lint<=1.41.0; python_version >= "3.14"
+    cfn-lint>=0.40.0; python_version < "3.14"
     jsonschema
     openapi-spec-validator>=0.5.0
 	pydantic<=2.12.4
@@ -67,7 +68,8 @@ proxy =
     docker>=2.5.1
     graphql-core
     PyYAML>=5.1
-    cfn-lint>=0.40.0,<=1.41.0
+    cfn-lint<=1.41.0; python_version >= "3.14"
+    cfn-lint>=0.40.0; python_version < "3.14"
     openapi-spec-validator>=0.5.0
 	pydantic<=2.12.4
     pyparsing>=3.0.7
@@ -84,7 +86,8 @@ server =
     docker>=3.0.0
     graphql-core
     PyYAML>=5.1
-    cfn-lint>=0.40.0,<=1.41.0
+    cfn-lint<=1.41.0; python_version >= "3.14"
+    cfn-lint>=0.40.0; python_version < "3.14"
     openapi-spec-validator>=0.5.0
 	pydantic<=2.12.4
     pyparsing>=3.0.7
@@ -119,7 +122,8 @@ cloudformation =
     docker>=3.0.0
     graphql-core
     PyYAML>=5.1
-    cfn-lint>=0.40.0,<=1.41.0
+    cfn-lint<=1.41.0; python_version >= "3.14"
+    cfn-lint>=0.40.0; python_version < "3.14"
     openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
     py-partiql-parser==0.6.3
@@ -207,7 +211,8 @@ resourcegroupstaggingapi =
     docker>=3.0.0
     graphql-core
     PyYAML>=5.1
-    cfn-lint>=0.40.0,<=1.41.0
+    cfn-lint<=1.41.0; python_version >= "3.14"
+    cfn-lint>=0.40.0; python_version < "3.14"
     openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
     py-partiql-parser==0.6.3


### PR DESCRIPTION
This PR extends conditional pinning based on Python version to `cfn-lint`.

The current unconditional pins were added upstream in https://github.com/getmoto/moto/pull/9521 due to missing Python 3.14 support in some dependencies. However, LocalStack is on Python 3.13 and all these constraints do is [fail dependency resolution](https://github.com/localstack/localstack/actions/runs/21813536966/job/62930429006). The latest failure is happening after Moto-Ext was re-pinned to the post hard fork release in https://github.com/localstack/localstack/pull/13698.

Also see https://github.com/localstack/moto/pull/80.