### PR TITLE
Pin pydantic only for Python 3.14 and above

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ all =
     cfn-lint>=0.40.0; python_version < "3.14"
     jsonschema
     openapi-spec-validator>=0.5.0
-	pydantic<=2.12.4
+	pydantic<=2.12.4; python_version >= "3.14"
     pyparsing>=3.0.7
     py-partiql-parser==0.6.3
     aws-xray-sdk!=0.96,>=0.93
@@ -71,7 +71,7 @@ proxy =
     cfn-lint<=1.41.0; python_version >= "3.14"
     cfn-lint>=0.40.0; python_version < "3.14"
     openapi-spec-validator>=0.5.0
-	pydantic<=2.12.4
+	pydantic<=2.12.4; python_version >= "3.14"
     pyparsing>=3.0.7
     py-partiql-parser==0.6.3
     aws-xray-sdk!=0.96,>=0.93
@@ -89,7 +89,7 @@ server =
     cfn-lint<=1.41.0; python_version >= "3.14"
     cfn-lint>=0.40.0; python_version < "3.14"
     openapi-spec-validator>=0.5.0
-	pydantic<=2.12.4
+	pydantic<=2.12.4; python_version >= "3.14"
     pyparsing>=3.0.7
     py-partiql-parser==0.6.3
     aws-xray-sdk!=0.96,>=0.93


### PR DESCRIPTION
This PR pins `pydantic` conditionally for Python 3.14 and above, to fix dependency resolution failures in LocalStack.

Also see #103 