### PR TITLE
update link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # moto-ext
 
-Fork of [Moto](https://github.com/getmoto/moto) with patches and fixes for [LocalStack](https://github.com/localstack/localstack).
+Fork of [Moto](https://github.com/getmoto/moto) with patches and fixes for [LocalStack for AWS](https://www.localstack.cloud/localstack-for-aws).


### PR DESCRIPTION
## Motivation
With the [upcoming changes](https://blog.localstack.cloud/the-road-ahead-for-localstack/) to consolidate the emulator images, the Community repo linked in the README will not be the primary point of contact anymore. This PR updates the link in the README to link towards our website instead.

Fixes ENG-401

## Changes
- Update the README to link towards the website instead of the GitHub repo.