### PR TITLE
ec2: Add dry run error handling for fleet creation

### DIFF
--- a/moto/ec2/responses/fleets.py
+++ b/moto/ec2/responses/fleets.py
@@ -68,6 +68,8 @@ class Fleets(EC2BaseResponse):
 
         tag_specifications = self._get_param("TagSpecifications", [])
 
+        self.error_on_dryrun()
+
         request = self.ec2_backend.create_fleet(
             on_demand_options=on_demand_options,
             spot_options=spot_options,


### PR DESCRIPTION
## Motivation

Karpenter calls `create_fleet` operation with `DryRun=true`
Current moto implementation still tries to create these ec2 instances, which leads to unexpected behavior

## Changes 

Add proper response and return early when dry run is used in fleet creation