### PR TITLE
ec2: Enhance fleet creation with LaunchTemplateAndOverrides in responses

### DIFF
--- a/moto/ec2/models/fleets.py
+++ b/moto/ec2/models/fleets.py
@@ -60,7 +60,6 @@ class Fleet(TaggedEC2Resource):
 
         self.launch_specs: list[SpotFleetLaunchSpec] = []
 
-        launch_specs_from_config: list[dict[str, Any]] = []
         for config in launch_template_configs or []:
             launch_spec = config["LaunchTemplateSpecification"]
             if "LaunchTemplateId" in launch_spec:
@@ -73,33 +72,49 @@ class Fleet(TaggedEC2Resource):
                 )
             else:
                 continue
-            launch_template_data = launch_template.latest_version().data
-            new_launch_template = launch_template_data.copy()
-            if config.get("Overrides"):
-                for override in config["Overrides"]:
-                    new_launch_template.update(override)
-            launch_specs_from_config.append(new_launch_template)
 
-        for spec in launch_specs_from_config:
-            tag_spec_set = spec.get("TagSpecifications", [])
-            tags = convert_tag_spec(tag_spec_set)
-            tags["instance"] = tags.get("instance", {}) | instance_tags
-            self.launch_specs.append(
-                SpotFleetLaunchSpec(
-                    ebs_optimized=spec.get("EbsOptimized"),
-                    group_set=spec.get("GroupSet", []),
-                    iam_instance_profile=spec.get("IamInstanceProfile"),
-                    image_id=spec["ImageId"],
-                    instance_type=spec["InstanceType"],
-                    key_name=spec.get("KeyName"),
-                    monitoring=spec.get("Monitoring"),
-                    spot_price=spec.get("SpotPrice"),
-                    subnet_id=spec.get("SubnetId"),
-                    tag_specifications=tags,
-                    user_data=spec.get("UserData"),
-                    weighted_capacity=spec.get("WeightedCapacity", 1),
+            # Resolve $Latest or $Default to actual version number
+            resolved_launch_spec = launch_spec.copy()
+            if resolved_launch_spec.get("Version") == "$Latest":
+                resolved_launch_spec["Version"] = str(
+                    launch_template.latest_version_number
                 )
-            )
+            elif resolved_launch_spec.get("Version") == "$Default":
+                resolved_launch_spec["Version"] = str(
+                    launch_template.default_version_number
+                )
+            # Always include the template ID in response (AWS does this even when name is used)
+            resolved_launch_spec["LaunchTemplateId"] = launch_template.id
+
+            launch_template_data = launch_template.latest_version().data
+            overrides_list = config.get("Overrides") or [{}]
+            for override in overrides_list:
+                # Merge launch template data with override
+                spec = launch_template_data.copy()
+                spec.update(override)
+
+                tag_spec_set = spec.get("TagSpecifications", [])
+                tags = convert_tag_spec(tag_spec_set)
+                tags["instance"] = tags.get("instance", {}) | instance_tags
+
+                self.launch_specs.append(
+                    SpotFleetLaunchSpec(
+                        ebs_optimized=spec.get("EbsOptimized"),
+                        group_set=spec.get("GroupSet", []),
+                        iam_instance_profile=spec.get("IamInstanceProfile"),
+                        image_id=spec["ImageId"],
+                        instance_type=spec["InstanceType"],
+                        key_name=spec.get("KeyName"),
+                        monitoring=spec.get("Monitoring"),
+                        spot_price=spec.get("SpotPrice"),
+                        subnet_id=spec.get("SubnetId"),
+                        tag_specifications=tags,
+                        user_data=spec.get("UserData"),
+                        weighted_capacity=spec.get("WeightedCapacity", 1),
+                        launch_template_spec=resolved_launch_spec,
+                        overrides=override,
+                    )
+                )
 
         self.spot_requests: list[SpotInstanceRequest] = []
         self.on_demand_instances: list[dict[str, Any]] = []
@@ -150,6 +165,59 @@ class Fleet(TaggedEC2Resource):
     def physical_resource_id(self) -> str:
         return self.id
 
+    @property
+    def instances(self) -> Optional[list[dict[str, Any]]]:
+        """
+        Return instances for instant fleets, None for other fleet types.
+        This is part of the CreateFleet response for instant fleets only.
+        """
+        if self.fleet_type != "instant":
+            return None
+
+        instances = []
+
+        # Process on-demand instances
+        for item in self.on_demand_instances:
+            instance_data = self._build_instance_data(
+                instance=item["instance"],
+                lifecycle="on-demand",
+                launch_spec=item.get("launch_spec"),
+            )
+            instances.append(instance_data)
+
+        # Process spot instances
+        for spot_request in self.spot_requests:
+            instance_data = self._build_instance_data(
+                instance=spot_request.instance,
+                lifecycle="spot",
+                launch_spec=spot_request.launch_spec,
+            )
+            instances.append(instance_data)
+
+        return instances
+
+    @staticmethod
+    def _build_instance_data(
+        instance: Any, lifecycle: str, launch_spec: Optional[SpotFleetLaunchSpec]
+    ) -> dict[str, Any]:
+        instance_data = {
+            "Lifecycle": lifecycle,
+            "InstanceIds": [instance.id],
+            "InstanceType": instance.instance_type,
+        }
+
+        # Add launch template and overrides if available
+        if launch_spec and launch_spec.launch_template_spec:
+            launch_template_and_overrides = {
+                "LaunchTemplateSpecification": launch_spec.launch_template_spec
+            }
+            if launch_spec.overrides:
+                launch_template_and_overrides["Overrides"] = launch_spec.overrides
+
+            instance_data["LaunchTemplateAndOverrides"] = launch_template_and_overrides
+
+        return instance_data
+
     def create_spot_requests(self, weight_to_add: float) -> list[SpotInstanceRequest]:
         weight_map, added_weight = self.get_launch_spec_counts(weight_to_add)
         for launch_spec, count in weight_map.items():
@@ -173,6 +241,7 @@ class Fleet(TaggedEC2Resource):
                 subnet_id=launch_spec.subnet_id,
                 spot_fleet_id=self.id,
                 tags=launch_spec.tag_specifications,
+                launch_spec=launch_spec,
             )
             self.spot_requests.extend(requests)
         self.fulfilled_capacity += added_weight
@@ -204,6 +273,7 @@ class Fleet(TaggedEC2Resource):
                 {
                     "id": reservation.id,
                     "instance": instance,
+                    "launch_spec": launch_spec,
                 }
             )
         self.fulfilled_capacity += added_weight

--- a/moto/ec2/responses/fleets.py
+++ b/moto/ec2/responses/fleets.py
@@ -70,7 +70,7 @@ class Fleets(EC2BaseResponse):
 
         self.error_on_dryrun()
 
-        request = self.ec2_backend.create_fleet(
+        fleet = self.ec2_backend.create_fleet(
             on_demand_options=on_demand_options,
             spot_options=spot_options,
             target_capacity_specification=target_capacity_specification,
@@ -83,26 +83,7 @@ class Fleets(EC2BaseResponse):
             valid_until=valid_until,
             tag_specifications=tag_specifications,
         )
-        result = {"FleetId": request.id}
-        if request.fleet_type == "instant":
-            # On Demand and Spot Instances are stored as incompatible types on the backend,
-            # so we have to do some extra work here.
-            # TODO: This should be addressed on the backend.
-            on_demand_instances = [
-                {
-                    "Lifecycle": "on-demand",
-                    "InstanceIds": [instance["instance"].id],
-                    "InstanceType": instance["instance"].instance_type,
-                }
-                for instance in request.on_demand_instances
-            ]
-            spot_requests = [
-                {
-                    "Lifecycle": "spot",
-                    "InstanceIds": [instance.instance.id],
-                    "InstanceType": instance.instance.instance_type,
-                }
-                for instance in request.spot_requests
-            ]
-            result["Instances"] = on_demand_instances + spot_requests
+        result = {"FleetId": fleet.id}
+        if fleet.instances is not None:
+            result["Instances"] = fleet.instances
         return ActionResult(result)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,12 @@
+import logging
+
 import boto3
 import pytest
 
 from moto import mock_aws
 from moto.utilities.id_generator import ResourceIdentifier, moto_id_manager
+
+LOG = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="function")
@@ -33,3 +37,20 @@ def set_custom_id():
 
     for resource_identifier in set_ids:
         moto_id_manager.unset_custom_id(resource_identifier)
+
+
+@pytest.fixture
+def cleanups():
+    cleanup_fns = []
+
+    yield cleanup_fns
+
+    for cleanup_callback in cleanup_fns[::-1]:
+        try:
+            cleanup_callback()
+        except Exception as e:
+            LOG.warning(
+                "Failed to execute cleanup due to unexpected error: %s",
+                str(e),
+                exc_info=e,
+            )

--- a/tests/test_ec2/test_fleets.py
+++ b/tests/test_ec2/test_fleets.py
@@ -912,45 +912,43 @@ def test_user_data():
 @pytest.mark.aws_verified
 @ec2_aws_verified()
 @pytest.mark.parametrize("version_specified", ["$Latest", "$Default"])
-def test_version_resolves_to_actual_version_number(version_specified, ec2_client=None):
+def test_version_resolves_to_actual_version_number(
+    version_specified, cleanups, ec2_client=None
+):
     """Test that $Latest or $Default in a fleet LaunchTemplateSpecification resolves to the actual version number"""
     with launch_template_context() as ctxt:
-        fleet_id = None
-        instance_ids = []
-        try:
-            fleet_response = ctxt.ec2.create_fleet(
-                LaunchTemplateConfigs=[
-                    {
-                        "LaunchTemplateSpecification": {
-                            "LaunchTemplateId": ctxt.lt_id,
-                            "Version": version_specified,
-                        },
-                        "Overrides": [{"InstanceType": "t3.micro"}],
-                    }
-                ],
-                TargetCapacitySpecification={
-                    "TotalTargetCapacity": 1,
-                    "OnDemandTargetCapacity": 1,
-                    "SpotTargetCapacity": 0,
-                    "DefaultTargetCapacityType": "on-demand",
-                },
-                OnDemandOptions={"AllocationStrategy": "lowest-price"},
-                Type="instant",
-            )
-            fleet_id = fleet_response["FleetId"]
-            instances = fleet_response["Instances"]
-            instance_ids = [i for inst in instances for i in inst["InstanceIds"]]
+        fleet_response = ctxt.ec2.create_fleet(
+            LaunchTemplateConfigs=[
+                {
+                    "LaunchTemplateSpecification": {
+                        "LaunchTemplateId": ctxt.lt_id,
+                        "Version": version_specified,
+                    },
+                    "Overrides": [{"InstanceType": "t3.micro"}],
+                }
+            ],
+            TargetCapacitySpecification={
+                "TotalTargetCapacity": 1,
+                "OnDemandTargetCapacity": 1,
+                "SpotTargetCapacity": 0,
+                "DefaultTargetCapacityType": "on-demand",
+            },
+            OnDemandOptions={"AllocationStrategy": "lowest-price"},
+            Type="instant",
+        )
+        fleet_id = fleet_response["FleetId"]
+        cleanups.append(
+            lambda: ctxt.ec2.delete_fleets(FleetIds=[fleet_id], TerminateInstances=True)
+        )
+        instances = fleet_response["Instances"]
+        instance_ids = [i for inst in instances for i in inst["InstanceIds"]]
+        cleanups.append(lambda: ctxt.ec2.terminate_instances(InstanceIds=instance_ids))
 
-            for instance in instances:
-                lt_spec_response = instance["LaunchTemplateAndOverrides"][
-                    "LaunchTemplateSpecification"
-                ]
-                assert lt_spec_response["Version"] == "1"
-        finally:
-            if fleet_id:
-                ctxt.ec2.delete_fleets(FleetIds=[fleet_id], TerminateInstances=False)
-            if instance_ids:
-                ctxt.ec2.terminate_instances(InstanceIds=instance_ids)
+        for instance in instances:
+            lt_spec_response = instance["LaunchTemplateAndOverrides"][
+                "LaunchTemplateSpecification"
+            ]
+            assert lt_spec_response["Version"] == "1"
 
 
 @ec2_aws_verified()
@@ -983,85 +981,80 @@ def test_create_instant_fleet_with_launch_template_overrides(
     overrides,
     on_demand_count,
     spot_count,
+    cleanups,
     ec2_client=None,
 ):
     """Test that LaunchTemplateAndOverrides is included in instant fleet responses"""
     expected_instance_types = {o["InstanceType"] for o in overrides}
 
     with launch_template_context(region=ec2_client.meta.region_name) as ctxt:
-        fleet_id = None
-        instance_ids = []
+        if use_template_name:
+            lt_spec = {"LaunchTemplateName": ctxt.lt_name, "Version": "$Latest"}
+        else:
+            lt_spec = {"LaunchTemplateId": ctxt.lt_id, "Version": "$Latest"}
 
-        try:
-            if use_template_name:
-                lt_spec = {"LaunchTemplateName": ctxt.lt_name, "Version": "$Latest"}
-            else:
-                lt_spec = {"LaunchTemplateId": ctxt.lt_id, "Version": "$Latest"}
-
-            total_capacity = on_demand_count + spot_count
-            fleet_request = {
-                "LaunchTemplateConfigs": [
-                    {
-                        "LaunchTemplateSpecification": lt_spec,
-                        "Overrides": overrides,
-                    }
-                ],
-                "TargetCapacitySpecification": {
-                    "TotalTargetCapacity": total_capacity,
-                    "OnDemandTargetCapacity": on_demand_count,
-                    "SpotTargetCapacity": spot_count,
-                    "DefaultTargetCapacityType": "on-demand"
-                    if on_demand_count > 0
-                    else "spot",
-                },
-                "Type": "instant",
-            }
-
-            if on_demand_count > 0:
-                fleet_request["OnDemandOptions"] = {
-                    "AllocationStrategy": "lowest-price"
+        total_capacity = on_demand_count + spot_count
+        fleet_request = {
+            "LaunchTemplateConfigs": [
+                {
+                    "LaunchTemplateSpecification": lt_spec,
+                    "Overrides": overrides,
                 }
-            if spot_count > 0:
-                fleet_request["SpotOptions"] = {"AllocationStrategy": "lowest-price"}
+            ],
+            "TargetCapacitySpecification": {
+                "TotalTargetCapacity": total_capacity,
+                "OnDemandTargetCapacity": on_demand_count,
+                "SpotTargetCapacity": spot_count,
+                "DefaultTargetCapacityType": "on-demand"
+                if on_demand_count > 0
+                else "spot",
+            },
+            "Type": "instant",
+        }
 
-            fleet_response = ctxt.ec2.create_fleet(**fleet_request)
+        if on_demand_count > 0:
+            fleet_request["OnDemandOptions"] = {"AllocationStrategy": "lowest-price"}
+        if spot_count > 0:
+            fleet_request["SpotOptions"] = {"AllocationStrategy": "lowest-price"}
 
-            # Verify response structure
-            assert "FleetId" in fleet_response
-            assert "Instances" in fleet_response
-            fleet_id = fleet_response["FleetId"]
+        fleet_response = ctxt.ec2.create_fleet(**fleet_request)
 
-            instances = fleet_response["Instances"]
-            # AWS groups instances with same config, moto returns them separately
-            # Count total instance IDs across all items
-            total_instance_ids = []
-            for inst in instances:
-                total_instance_ids.extend(inst["InstanceIds"])
-            assert len(total_instance_ids) == total_capacity
+        # Verify response structure
+        assert "FleetId" in fleet_response
+        fleet_id = fleet_response["FleetId"]
+        cleanups.append(
+            lambda: ctxt.ec2.delete_fleets(FleetIds=[fleet_id], TerminateInstances=True)
+        )
 
-            instance_ids.extend(total_instance_ids)
+        assert "Instances" in fleet_response
 
-            # Verify lifecycles if mixed
-            if on_demand_count > 0 and spot_count > 0:
-                lifecycles = {instance["Lifecycle"] for instance in instances}
-                assert "on-demand" in lifecycles
-                assert "spot" in lifecycles
+        instances = fleet_response["Instances"]
+        # AWS groups instances with same config, moto returns them separately
+        # Count total instance IDs across all items
+        total_instance_ids = []
+        for inst in instances:
+            total_instance_ids.extend(inst["InstanceIds"])
+        assert len(total_instance_ids) == total_capacity
 
-            for instance in instances:
-                assert "LaunchTemplateAndOverrides" in instance
+        cleanups.append(
+            lambda: ctxt.ec2.terminate_instances(InstanceIds=total_instance_ids)
+        )
 
-                lt_and_overrides = instance["LaunchTemplateAndOverrides"]
-                assert "LaunchTemplateSpecification" in lt_and_overrides
+        # Verify lifecycles if mixed
+        if on_demand_count > 0 and spot_count > 0:
+            lifecycles = {instance["Lifecycle"] for instance in instances}
+            assert "on-demand" in lifecycles
+            assert "spot" in lifecycles
 
-                lt_spec_response = lt_and_overrides["LaunchTemplateSpecification"]
-                assert lt_spec_response["LaunchTemplateId"] == ctxt.lt_id
+        for instance in instances:
+            assert "LaunchTemplateAndOverrides" in instance
 
-                assert "Overrides" in lt_and_overrides
-                overrides_response = lt_and_overrides["Overrides"]
-                assert overrides_response["InstanceType"] in expected_instance_types
+            lt_and_overrides = instance["LaunchTemplateAndOverrides"]
+            assert "LaunchTemplateSpecification" in lt_and_overrides
 
-        finally:
-            if fleet_id:
-                ctxt.ec2.delete_fleets(FleetIds=[fleet_id], TerminateInstances=False)
-            if instance_ids:
-                ctxt.ec2.terminate_instances(InstanceIds=instance_ids)
+            lt_spec_response = lt_and_overrides["LaunchTemplateSpecification"]
+            assert lt_spec_response["LaunchTemplateId"] == ctxt.lt_id
+
+            assert "Overrides" in lt_and_overrides
+            overrides_response = lt_and_overrides["Overrides"]
+            assert overrides_response["InstanceType"] in expected_instance_types

--- a/tests/test_ec2/test_fleets.py
+++ b/tests/test_ec2/test_fleets.py
@@ -27,8 +27,6 @@ def get_launch_template(conn, instance_type="t2.micro", ami_id=EXAMPLE_AMI_ID):
         LaunchTemplateData={
             "ImageId": ami_id,
             "InstanceType": instance_type,
-            "KeyName": "test",
-            "SecurityGroups": ["sg-123456"],
             "DisableApiTermination": False,
             "TagSpecifications": [
                 {
@@ -909,3 +907,161 @@ def test_user_data():
         Attribute="userData",
     )
     assert attrs["UserData"]["Value"] == str(user_data)
+
+
+@pytest.mark.aws_verified
+@ec2_aws_verified()
+@pytest.mark.parametrize("version_specified", ["$Latest", "$Default"])
+def test_version_resolves_to_actual_version_number(version_specified, ec2_client=None):
+    """Test that $Latest or $Default in a fleet LaunchTemplateSpecification resolves to the actual version number"""
+    with launch_template_context() as ctxt:
+        fleet_id = None
+        instance_ids = []
+        try:
+            fleet_response = ctxt.ec2.create_fleet(
+                LaunchTemplateConfigs=[
+                    {
+                        "LaunchTemplateSpecification": {
+                            "LaunchTemplateId": ctxt.lt_id,
+                            "Version": version_specified,
+                        },
+                        "Overrides": [{"InstanceType": "t3.micro"}],
+                    }
+                ],
+                TargetCapacitySpecification={
+                    "TotalTargetCapacity": 1,
+                    "OnDemandTargetCapacity": 1,
+                    "SpotTargetCapacity": 0,
+                    "DefaultTargetCapacityType": "on-demand",
+                },
+                OnDemandOptions={"AllocationStrategy": "lowest-price"},
+                Type="instant",
+            )
+            fleet_id = fleet_response["FleetId"]
+            instances = fleet_response["Instances"]
+            instance_ids = [i for inst in instances for i in inst["InstanceIds"]]
+
+            for instance in instances:
+                lt_spec_response = instance["LaunchTemplateAndOverrides"][
+                    "LaunchTemplateSpecification"
+                ]
+                assert lt_spec_response["Version"] == "1"
+        finally:
+            if fleet_id:
+                ctxt.ec2.delete_fleets(FleetIds=[fleet_id], TerminateInstances=False)
+            if instance_ids:
+                ctxt.ec2.terminate_instances(InstanceIds=instance_ids)
+
+
+@ec2_aws_verified()
+@pytest.mark.parametrize(
+    "use_template_name", [False, True], ids=["template-id", "template-name"]
+)
+@pytest.mark.parametrize(
+    ["on_demand_count", "spot_count"],
+    [
+        pytest.param(1, 0, id="on-demand-only"),
+        pytest.param(0, 2, id="spot-only"),
+        pytest.param(1, 2, id="mixed-on-demand-spot"),
+    ],
+)
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        pytest.param(
+            [{"InstanceType": "t3.micro"}, {"InstanceType": "t3.nano"}],
+            id="multi-override",
+        ),
+        pytest.param(
+            [{"InstanceType": "t3.micro"}],
+            id="single-override",
+        ),
+    ],
+)
+def test_create_instant_fleet_with_launch_template_overrides(
+    use_template_name,
+    overrides,
+    on_demand_count,
+    spot_count,
+    ec2_client=None,
+):
+    """Test that LaunchTemplateAndOverrides is included in instant fleet responses"""
+    expected_instance_types = {o["InstanceType"] for o in overrides}
+
+    with launch_template_context(region=ec2_client.meta.region_name) as ctxt:
+        fleet_id = None
+        instance_ids = []
+
+        try:
+            if use_template_name:
+                lt_spec = {"LaunchTemplateName": ctxt.lt_name, "Version": "$Latest"}
+            else:
+                lt_spec = {"LaunchTemplateId": ctxt.lt_id, "Version": "$Latest"}
+
+            total_capacity = on_demand_count + spot_count
+            fleet_request = {
+                "LaunchTemplateConfigs": [
+                    {
+                        "LaunchTemplateSpecification": lt_spec,
+                        "Overrides": overrides,
+                    }
+                ],
+                "TargetCapacitySpecification": {
+                    "TotalTargetCapacity": total_capacity,
+                    "OnDemandTargetCapacity": on_demand_count,
+                    "SpotTargetCapacity": spot_count,
+                    "DefaultTargetCapacityType": "on-demand"
+                    if on_demand_count > 0
+                    else "spot",
+                },
+                "Type": "instant",
+            }
+
+            if on_demand_count > 0:
+                fleet_request["OnDemandOptions"] = {
+                    "AllocationStrategy": "lowest-price"
+                }
+            if spot_count > 0:
+                fleet_request["SpotOptions"] = {"AllocationStrategy": "lowest-price"}
+
+            fleet_response = ctxt.ec2.create_fleet(**fleet_request)
+
+            # Verify response structure
+            assert "FleetId" in fleet_response
+            assert "Instances" in fleet_response
+            fleet_id = fleet_response["FleetId"]
+
+            instances = fleet_response["Instances"]
+            # AWS groups instances with same config, moto returns them separately
+            # Count total instance IDs across all items
+            total_instance_ids = []
+            for inst in instances:
+                total_instance_ids.extend(inst["InstanceIds"])
+            assert len(total_instance_ids) == total_capacity
+
+            instance_ids.extend(total_instance_ids)
+
+            # Verify lifecycles if mixed
+            if on_demand_count > 0 and spot_count > 0:
+                lifecycles = {instance["Lifecycle"] for instance in instances}
+                assert "on-demand" in lifecycles
+                assert "spot" in lifecycles
+
+            for instance in instances:
+                assert "LaunchTemplateAndOverrides" in instance
+
+                lt_and_overrides = instance["LaunchTemplateAndOverrides"]
+                assert "LaunchTemplateSpecification" in lt_and_overrides
+
+                lt_spec_response = lt_and_overrides["LaunchTemplateSpecification"]
+                assert lt_spec_response["LaunchTemplateId"] == ctxt.lt_id
+
+                assert "Overrides" in lt_and_overrides
+                overrides_response = lt_and_overrides["Overrides"]
+                assert overrides_response["InstanceType"] in expected_instance_types
+
+        finally:
+            if fleet_id:
+                ctxt.ec2.delete_fleets(FleetIds=[fleet_id], TerminateInstances=False)
+            if instance_ids:
+                ctxt.ec2.terminate_instances(InstanceIds=instance_ids)

--- a/tests/test_ec2/test_instance_types.py
+++ b/tests/test_ec2/test_instance_types.py
@@ -59,8 +59,8 @@ def test_describe_instance_types_gpu_instance_types():
                     "MemoryInfo": {"SizeInMiB": 8192},
                     "Name": "Radeon Pro V520",
                     "Workloads": [
-                        "ml-ai",
                         "graphics",
+                        "ml-ai",
                     ],
                 }
             ],


### PR DESCRIPTION
## Motivation 

When creating an EC2 Fleet with `Type=instant`, the response was missing the `LaunchTemplateAndOverrides` field for each instance. This field is present in real AWS responses and contains important information about which launch template and overrides were used to launch each instance.
Note: this field is necessary for Karpenter, otherwise it fails to parse the response.

## Changes

* The 'Instances` array in the `create_fleet` response now includes `LaunchTemplateAndOverrides` with:
  * `LaunchTemplateSpecification` - Launch template ID and version used
  * `Overrides` - Any overrides applied (instance type, subnet, AZ, etc.) 
* Version resolution: `$Latest` is now resolved to the actual version number (e.g., "1") in responses, matching AWS
* Template ID normalization: When LaunchTemplateName is used in the request, the response always includes LaunchTemplateId (AWS behavior)



