### PR TITLE
ec2: Fix Fleet on-demand instance provisioning

### DIFF
--- a/moto/ec2/models/fleets.py
+++ b/moto/ec2/models/fleets.py
@@ -131,9 +131,7 @@ class Fleet(TaggedEC2Resource):
         if self.spot_target_capacity > 0:
             self.create_spot_requests(self.spot_target_capacity)
         self.on_demand_target_capacity = int(
-            target_capacity_specification.get(
-                "OnDemandTargetCapacity", self.target_capacity
-            )
+            target_capacity_specification.get("OnDemandTargetCapacity", 0)
         )
         if self.on_demand_target_capacity > 0:
             self.create_on_demand_requests(self.on_demand_target_capacity)
@@ -267,15 +265,14 @@ class Fleet(TaggedEC2Resource):
                 tags=launch_spec.tag_specifications,
             )
 
-            # get the instance from the reservation
-            instance = reservation.instances[0]
-            self.on_demand_instances.append(
-                {
-                    "id": reservation.id,
-                    "instance": instance,
-                    "launch_spec": launch_spec,
-                }
-            )
+            for instance in reservation.instances:
+                self.on_demand_instances.append(
+                    {
+                        "id": reservation.id,
+                        "instance": instance,
+                        "launch_spec": launch_spec,
+                    }
+                )
         self.fulfilled_capacity += added_weight
 
     def get_launch_spec_counts(

--- a/tests/test_ec2/test_fleets.py
+++ b/tests/test_ec2/test_fleets.py
@@ -114,6 +114,135 @@ def test_create_fleet_dryrun(ec2_client=None):
         assert len(instances_res["Reservations"]) == reservations_before
 
 
+@pytest.mark.aws_verified
+@ec2_aws_verified()
+@pytest.mark.parametrize(
+    ["target_capacity_specification", "expected_on_demand", "expected_spot"],
+    [
+        pytest.param(
+            {"TotalTargetCapacity": 2, "DefaultTargetCapacityType": "on-demand"},
+            2,
+            0,
+            id="default-on-demand-only",
+        ),
+        pytest.param(
+            {"TotalTargetCapacity": 2, "DefaultTargetCapacityType": "spot"},
+            0,
+            2,
+            id="default-spot-only",
+        ),
+        pytest.param(
+            {
+                "TotalTargetCapacity": 2,
+                "OnDemandTargetCapacity": 2,
+                "SpotTargetCapacity": 0,
+                "DefaultTargetCapacityType": "on-demand",
+            },
+            2,
+            0,
+            id="explicit-on-demand-only",
+        ),
+        pytest.param(
+            {
+                "TotalTargetCapacity": 2,
+                "OnDemandTargetCapacity": 0,
+                "SpotTargetCapacity": 2,
+                "DefaultTargetCapacityType": "spot",
+            },
+            0,
+            2,
+            id="explicit-spot-only",
+        ),
+        pytest.param(
+            {
+                "TotalTargetCapacity": 2,
+                "OnDemandTargetCapacity": 1,
+                "SpotTargetCapacity": 1,
+                "DefaultTargetCapacityType": "on-demand",
+            },
+            1,
+            1,
+            id="explicit-mixed-default-on-demand",
+        ),
+        pytest.param(
+            {
+                "TotalTargetCapacity": 2,
+                "OnDemandTargetCapacity": 1,
+                "SpotTargetCapacity": 1,
+                "DefaultTargetCapacityType": "spot",
+            },
+            1,
+            1,
+            id="explicit-mixed-default-spot",
+        ),
+        pytest.param(
+            {
+                "TotalTargetCapacity": 3,
+                "OnDemandTargetCapacity": 1,
+                "DefaultTargetCapacityType": "spot",
+            },
+            1,
+            2,
+            id="partial-on-demand-remainder-to-spot",
+        ),
+        pytest.param(
+            {
+                "TotalTargetCapacity": 3,
+                "SpotTargetCapacity": 1,
+                "DefaultTargetCapacityType": "on-demand",
+            },
+            2,
+            1,
+            id="partial-spot-remainder-to-on-demand",
+        ),
+    ],
+)
+def test_create_instant_fleet_target_capacity_combinations(
+    target_capacity_specification,
+    expected_on_demand,
+    expected_spot,
+    cleanups,
+    ec2_client=None,
+):
+    with launch_template_context(region=ec2_client.meta.region_name) as ctxt:
+        fleet_res = ctxt.ec2.create_fleet(
+            LaunchTemplateConfigs=[
+                {
+                    "LaunchTemplateSpecification": {
+                        "LaunchTemplateId": ctxt.lt_id,
+                        "Version": "1",
+                    },
+                },
+            ],
+            TargetCapacitySpecification=target_capacity_specification,
+            Type="instant",
+        )
+        fleet_id = fleet_res["FleetId"]
+        cleanups.append(
+            lambda: ec2_client.delete_fleets(
+                FleetIds=[fleet_id], TerminateInstances=True
+            )
+        )
+
+        instances = fleet_res.get("Instances", [])
+
+        on_demand_ids = [
+            iid
+            for entry in instances
+            if entry.get("Lifecycle") == "on-demand"
+            for iid in entry.get("InstanceIds", [])
+        ]
+        spot_ids = [
+            iid
+            for entry in instances
+            if entry.get("Lifecycle") == "spot"
+            for iid in entry.get("InstanceIds", [])
+        ]
+
+        assert len(on_demand_ids) == expected_on_demand
+        assert len(spot_ids) == expected_spot
+
+
 @mock_aws
 def test_create_spot_fleet_with_lowest_price():
     conn = boto3.client("ec2", region_name="us-west-2")


### PR DESCRIPTION
EC2 Fleet was not launching the correct number of on-demand instances in two scenarios:

* When `OnDemandTargetCapacity` was greater than 1, only a single instance was launched instead of the requested amount.
* When `OnDemandTargetCapacity` was omitted from the request, the remaining capacity fallback did not behave correctly.
