### PR TITLE
Fix ipv6CidrBlockState attribute

### DIFF
--- a/moto/ec2/models/subnets.py
+++ b/moto/ec2/models/subnets.py
@@ -128,9 +128,7 @@ class Subnet(TaggedEC2Resource, CloudFormationModel):
             {
                 "ipv6CidrBlock": association["ipv6CidrBlock"],
                 "associationId": association["associationId"],
-                "ipv6CidrBlockState": {
-                    "state": association["ipv6CidrBlockState"],
-                },
+                "ipv6CidrBlockState": association["ipv6CidrBlockState"],
             }
             for association in self.ipv6_cidr_block_associations.values()
             if association["ipv6CidrBlockState"]["State"] == "associated"

--- a/tests/test_ec2/__init__.py
+++ b/tests/test_ec2/__init__.py
@@ -234,6 +234,17 @@ def wait_for_ipv6_cidr_block_associations(ec2_client, vpc_id):
         sleep(5 * idx)
 
 
+def wait_for_subnet_ipv6_cidr_block_associations(ec2_client, subnet_id):
+    for idx in range(10):
+        subnets = ec2_client.describe_subnets(SubnetIds=[subnet_id])["Subnets"]
+        if (
+            subnets[0]["Ipv6CidrBlockAssociationSet"][0]["Ipv6CidrBlockState"]["State"]
+            == "associated"
+        ):
+            return subnets[0]["Ipv6CidrBlockAssociationSet"][0]
+        sleep(5 * idx)
+
+
 def delete_transit_gateway_dependencies(ec2_client, tg_id):
     delete_tg_attachments(ec2_client, tg_id)
 

--- a/tests/test_ec2/test_subnets.py
+++ b/tests/test_ec2/test_subnets.py
@@ -8,7 +8,7 @@ from botocore.exceptions import ClientError
 
 from moto import mock_aws, settings
 from tests import DEFAULT_ACCOUNT_ID, EXAMPLE_AMI_ID
-from tests.test_ec2 import ec2_aws_verified, wait_for_ipv6_cidr_block_associations
+from tests.test_ec2 import ec2_aws_verified, wait_for_ipv6_cidr_block_associations, wait_for_subnet_ipv6_cidr_block_associations
 
 from .helpers import assert_dryrun_error
 
@@ -996,6 +996,7 @@ def test_create_ipv6native_subnet(account_id, ec2_client=None, vpc_id=None):
         subnet = ec2_client.create_subnet(
             VpcId=vpc_id, Ipv6Native=True, Ipv6CidrBlock=assoc["Ipv6CidrBlock"]
         )["Subnet"]
+
         assert subnet["AssignIpv6AddressOnCreation"] is True
         assert subnet["Ipv6Native"] is True
         assert subnet["State"] == "available"
@@ -1003,6 +1004,8 @@ def test_create_ipv6native_subnet(account_id, ec2_client=None, vpc_id=None):
             subnet["Ipv6CidrBlockAssociationSet"][0]["Ipv6CidrBlock"]
             == assoc["Ipv6CidrBlock"]
         )
+        subnet_associated=wait_for_subnet_ipv6_cidr_block_associations(ec2_client, subnet["SubnetId"])
+        assert subnet_associated["Ipv6CidrBlockState"] == {"State": "associated"}
     finally:
         if subnet:
             ec2_client.delete_subnet(SubnetId=subnet["SubnetId"])

--- a/tests/test_ec2/test_subnets.py
+++ b/tests/test_ec2/test_subnets.py
@@ -8,7 +8,11 @@ from botocore.exceptions import ClientError
 
 from moto import mock_aws, settings
 from tests import DEFAULT_ACCOUNT_ID, EXAMPLE_AMI_ID
-from tests.test_ec2 import ec2_aws_verified, wait_for_ipv6_cidr_block_associations, wait_for_subnet_ipv6_cidr_block_associations
+from tests.test_ec2 import (
+    ec2_aws_verified,
+    wait_for_ipv6_cidr_block_associations,
+    wait_for_subnet_ipv6_cidr_block_associations,
+)
 
 from .helpers import assert_dryrun_error
 
@@ -1004,7 +1008,9 @@ def test_create_ipv6native_subnet(account_id, ec2_client=None, vpc_id=None):
             subnet["Ipv6CidrBlockAssociationSet"][0]["Ipv6CidrBlock"]
             == assoc["Ipv6CidrBlock"]
         )
-        subnet_associated=wait_for_subnet_ipv6_cidr_block_associations(ec2_client, subnet["SubnetId"])
+        subnet_associated = wait_for_subnet_ipv6_cidr_block_associations(
+            ec2_client, subnet["SubnetId"]
+        )
         assert subnet_associated["Ipv6CidrBlockState"] == {"State": "associated"}
     finally:
         if subnet:

--- a/tests/test_ec2/test_subnets.py
+++ b/tests/test_ec2/test_subnets.py
@@ -892,6 +892,7 @@ def test_associate_subnet_cidr_block():
     assert len(association_set) == 1
     assert association_set[0]["AssociationId"] == association["AssociationId"]
     assert association_set[0]["Ipv6CidrBlock"] == "1080::1:200C:417A/112"
+    assert association_set[0]["Ipv6CidrBlockState"] == {"State": "associated"}
 
 
 @mock_aws


### PR DESCRIPTION
# Motivation

Currently, Moto returns the following when creating a subnet with ipv6:
```
"Ipv6CidrBlockAssociationSet": [
                {
                    "AssociationId": "subnet-cidr-assoc-ab535847242c5253b",
                    "Ipv6CidrBlock": "2400:6500:eb2:8c01::/64",
                    "Ipv6CidrBlockState": {
                        "State": "{'State': 'associated'}"  <<<---- THIS CAUSES ISSUES ON TERRAFORM
                    }
                }
            ],
```
Instead it should return something like this:
```
"Ipv6CidrBlockAssociationSet": [
                {
                    "AssociationId": "subnet-cidr-assoc-06d8ec089f3bde95f",
                    "Ipv6CidrBlock": "2600:1f18:e8:b701::/64",
                    "Ipv6CidrBlockState": {
                        "State": "associated"
                    },
                    "Ipv6AddressAttribute": "public",
                    "IpSource": "amazon"
                }
            ],
```
# Changes
- Modifies function `ipv6_cidr_block_association_set` so it returns the proper value. Here is some [reference](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_VpcCidrBlockState.html).