### PR TITLE
EC2: Resource name DNS options for subnets

### DIFF
--- a/moto/ec2/models/subnets.py
+++ b/moto/ec2/models/subnets.py
@@ -636,7 +636,7 @@ class SubnetBackend:
         raise InvalidSubnetIdError(subnet_id)
 
     def modify_subnet_attribute(
-        self, subnet_id: str, attr_name: str, attr_value: str | bool
+        self, subnet_id: str, attr_name: str, attr_value: bool
     ) -> None:
         subnet = self.get_subnet(subnet_id)
         if attr_name in ("map_public_ip_on_launch", "assign_ipv6_address_on_creation"):

--- a/moto/ec2/models/subnets.py
+++ b/moto/ec2/models/subnets.py
@@ -97,6 +97,11 @@ class Subnet(TaggedEC2Resource, CloudFormationModel):
         self.map_public_ip_on_launch = map_public_ip_on_launch
         self.assign_ipv6_address_on_creation = ipv6_native
         self.ipv6_cidr_block_associations: dict[str, dict[str, Any]] = {}
+        self.private_dns_name_options_on_launch = {
+            "HostnameType": "ip-name",
+            "EnableResourceNameDnsARecord": False,
+            "EnableResourceNameDnsAAAARecord": False,
+        }
         if ipv6_cidr_block:
             self.attach_ipv6_cidr_block_associations(ipv6_cidr_block)
 
@@ -631,11 +636,15 @@ class SubnetBackend:
         raise InvalidSubnetIdError(subnet_id)
 
     def modify_subnet_attribute(
-        self, subnet_id: str, attr_name: str, attr_value: str
+        self, subnet_id: str, attr_name: str, attr_value: str | bool
     ) -> None:
         subnet = self.get_subnet(subnet_id)
         if attr_name in ("map_public_ip_on_launch", "assign_ipv6_address_on_creation"):
             setattr(subnet, attr_name, attr_value)
+        elif attr_name == "enable_resource_name_dns_a_record_on_launch":
+            subnet.private_dns_name_options_on_launch[
+                "EnableResourceNameDnsARecord"
+            ] = attr_value
         else:
             raise InvalidParameterValueError(attr_name)
 

--- a/moto/ec2/responses/subnets.py
+++ b/moto/ec2/responses/subnets.py
@@ -67,7 +67,11 @@ class Subnets(EC2BaseResponse):
     def modify_subnet_attribute(self) -> ActionResult:
         subnet_id = self._get_param("SubnetId")
 
-        for attribute in ("MapPublicIpOnLaunch", "AssignIpv6AddressOnCreation"):
+        for attribute in (
+            "MapPublicIpOnLaunch",
+            "AssignIpv6AddressOnCreation",
+            "EnableResourceNameDnsARecordOnLaunch",
+        ):
             if self._get_param(f"{attribute}.Value") is not None:
                 attr_name = camelcase_to_underscores(attribute)
                 attr_value = self._get_param(f"{attribute}.Value")

--- a/tests/test_ec2/test_subnets.py
+++ b/tests/test_ec2/test_subnets.py
@@ -1017,6 +1017,43 @@ def test_create_ipv6native_subnet(account_id, ec2_client=None, vpc_id=None):
             ec2_client.delete_subnet(SubnetId=subnet["SubnetId"])
 
 
+@pytest.mark.aws_verified
+@ec2_aws_verified(create_vpc=True)
+def test_private_dns_name_options(ec2_client=None, vpc_id=None):
+    subnet = None
+    try:
+        subnet = ec2_client.create_subnet(
+            VpcId=vpc_id,
+            CidrBlock="10.0.0.0/24",
+        )["Subnet"]
+
+        assert "PrivateDnsNameOptionsOnLaunch" in subnet
+        assert subnet["PrivateDnsNameOptionsOnLaunch"]["HostnameType"] == "ip-name"
+        assert (
+            subnet["PrivateDnsNameOptionsOnLaunch"]["EnableResourceNameDnsARecord"]
+            is False
+        )
+        assert (
+            subnet["PrivateDnsNameOptionsOnLaunch"]["EnableResourceNameDnsAAAARecord"]
+            is False
+        )
+
+        ec2_client.modify_subnet_attribute(
+            SubnetId=subnet["SubnetId"],
+            EnableResourceNameDnsARecordOnLaunch={"Value": True},
+        )
+        subnet = ec2_client.describe_subnets(SubnetIds=[subnet["SubnetId"]])["Subnets"][
+            0
+        ]
+        assert (
+            subnet["PrivateDnsNameOptionsOnLaunch"]["EnableResourceNameDnsARecord"]
+            is True
+        )
+    finally:
+        if subnet:
+            ec2_client.delete_subnet(SubnetId=subnet["SubnetId"])
+
+
 @mock_aws
 def test_create_subnet_cidr_reservations() -> None:
     ec2 = boto3.client("ec2", region_name="us-west-1")


### PR DESCRIPTION
This PR implements support for DNS options in EC2 subnets.

- `DescribeSubnets` now returns the default values for [`privateDnsNameOptionsOnLaunch`](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_PrivateDnsNameOptionsOnLaunch.html)
- A records option (`EnableResourceNameDnsARecordOnLaunch`) can be modified using [`ModifySubnetAttribute`](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifySubnetAttribute.html)
- Includes a test validated against AWS

See https://github.com/localstack/localstack/issues/13113

Closes PNX-714