### PR TITLE
ec2: Add system tags to instances launched via fleet

### DIFF
--- a/moto/ec2/models/fleets.py
+++ b/moto/ec2/models/fleets.py
@@ -98,7 +98,17 @@ class Fleet(TaggedEC2Resource):
 
                 tag_spec_set = spec.get("TagSpecifications", [])
                 tags = convert_tag_spec(tag_spec_set)
-                tags["instance"] = tags.get("instance", {}) | instance_tags
+                # AWS automatically adds these system tags to all instances launched via a fleet
+                system_tags = {
+                    "aws:ec2:fleet-id": self.id,
+                    "aws:ec2launchtemplate:id": resolved_launch_spec[
+                        "LaunchTemplateId"
+                    ],
+                    "aws:ec2launchtemplate:version": resolved_launch_spec["Version"],
+                }
+                tags["instance"] = (
+                    system_tags | tags.get("instance", {}) | instance_tags
+                )
 
                 self.launch_specs.append(
                     SpotFleetLaunchSpec(


### PR DESCRIPTION
Attach AWS-managed tags (`aws:ec2:fleet-id`, `aws:ec2launchtemplate:id`, `aws:ec2launchtemplate:version`) to instances launched via a Fleet, matching the tags AWS automatically applies. 

Tested in https://github.com/localstack/localstack-pro/pull/6895