### PR TITLE
ec2: Always include launch template overrides in instance launch data

### DIFF
--- a/moto/ec2/models/fleets.py
+++ b/moto/ec2/models/fleets.py
@@ -210,11 +210,9 @@ class Fleet(TaggedEC2Resource):
         # Add launch template and overrides if available
         if launch_spec and launch_spec.launch_template_spec:
             launch_template_and_overrides = {
-                "LaunchTemplateSpecification": launch_spec.launch_template_spec
+                "LaunchTemplateSpecification": launch_spec.launch_template_spec,
+                "Overrides": launch_spec.overrides,
             }
-            if launch_spec.overrides:
-                launch_template_and_overrides["Overrides"] = launch_spec.overrides
-
             instance_data["LaunchTemplateAndOverrides"] = launch_template_and_overrides
 
         return instance_data


### PR DESCRIPTION
Previous version of moto-ext doesn't return `Overrides` if it's an empty `{}`
WIth this change we always return to match AWS response

Tested in https://github.com/localstack/localstack-pro/pull/6895