### PR TITLE
EC2: Honor TagSpecifications in CreateTransitGatewayVpcAttachment

### DIFF
--- a/moto/ec2/responses/transit_gateway_attachments.py
+++ b/moto/ec2/responses/transit_gateway_attachments.py
@@ -10,7 +10,7 @@ class TransitGatewayAttachment(EC2BaseResponse):
         transit_gateway_id = self._get_param("TransitGatewayId")
         vpc_id = self._get_param("VpcId")
 
-        tags = self._parse_tag_specification().get("transit-gateway-route-table", {})
+        tags = self._parse_tag_specification().get("transit-gateway-attachment", {})
 
         transit_gateway_attachment = (
             self.ec2_backend.create_transit_gateway_vpc_attachment(

--- a/tests/test_ec2/test_transit_gateway.py
+++ b/tests/test_ec2/test_transit_gateway.py
@@ -1,5 +1,6 @@
 from time import sleep
 from unittest import SkipTest
+from uuid import uuid4
 
 import boto3
 import pytest
@@ -627,6 +628,61 @@ def test_create_transit_gateway_vpc_attachment():
     assert attachment["SubnetIds"] == ["sub1"]
     assert attachment["State"] == "available"
     assert "Tags" not in attachment
+
+
+@pytest.mark.aws_verified
+@ec2_aws_verified(create_vpc=True, create_subnet=True, create_transit_gateway=True)
+def test_create_transit_gateway_vpc_attachment_with_tags(
+    account_id, ec2_client=None, vpc_id=None, subnet_id=None, tg_id=None
+):
+    name_tag = {"Key": "Name", "Value": f"my-attachment-{uuid4()}"}
+    team_tag = {"Key": "Team", "Value": f"platform-{uuid4()}"}
+    env_tag = {"Key": "Env", "Value": f"test-{uuid4()}"}
+
+    response = ec2_client.create_transit_gateway_vpc_attachment(
+        TransitGatewayId=tg_id,
+        VpcId=vpc_id,
+        SubnetIds=[subnet_id],
+        TagSpecifications=[
+            {
+                "ResourceType": "transit-gateway-attachment",
+                "Tags": [name_tag, team_tag],
+            }
+        ],
+    )
+    create = response["TransitGatewayVpcAttachment"]
+    tg_attachment_id = create["TransitGatewayAttachmentId"]
+    # AWS returns 'pending' - Moto is immediately 'available', so don't assert on State
+    assert len(create["Tags"]) == 2
+    assert name_tag in create["Tags"]
+    assert team_tag in create["Tags"]
+
+    # Wait until the attachment is fully ready
+    wait_for_transit_gateway_attachments(ec2_client, tg_attachment_id=tg_attachment_id)
+
+    vpc_attachment = ec2_client.describe_transit_gateway_vpc_attachments(
+        TransitGatewayAttachmentIds=[tg_attachment_id]
+    )["TransitGatewayVpcAttachments"][0]
+    assert len(vpc_attachment["Tags"]) == 2
+    assert name_tag in vpc_attachment["Tags"]
+    assert team_tag in vpc_attachment["Tags"]
+
+    tg_attachment = ec2_client.describe_transit_gateway_attachments(
+        TransitGatewayAttachmentIds=[tg_attachment_id]
+    )["TransitGatewayAttachments"][0]
+    assert len(tg_attachment["Tags"]) == 2
+    assert name_tag in tg_attachment["Tags"]
+    assert team_tag in tg_attachment["Tags"]
+
+    # Tags added after creation are merged with the create-time tags
+    ec2_client.create_tags(Resources=[tg_attachment_id], Tags=[env_tag])
+    vpc_attachment = ec2_client.describe_transit_gateway_vpc_attachments(
+        TransitGatewayAttachmentIds=[tg_attachment_id]
+    )["TransitGatewayVpcAttachments"][0]
+    assert len(vpc_attachment["Tags"]) == 3
+    assert name_tag in vpc_attachment["Tags"]
+    assert team_tag in vpc_attachment["Tags"]
+    assert env_tag in vpc_attachment["Tags"]
 
 
 @mock_aws


### PR DESCRIPTION
Fixes [SUP-138](https://linear.app/localstack/issue/SUP-138/create-time-tagspecifications-tags-for-tgw-vpc-attachments-not).

## Summary

Tags passed via `TagSpecifications` on `CreateTransitGatewayVpcAttachment` were silently dropped. `DescribeTransitGatewayVpcAttachments` and `DescribeTransitGatewayAttachments` returned no `Tags` for them, while tags added afterwards with `CreateTags` worked. In LocalStack this surfaced as Terraform's `aws_ec2_transit_gateway_vpc_attachment` re-adding its `tags` on every plan, and as `AWS::EC2::TransitGatewayAttachment` in CloudFormation losing its tags (that resource provider also sends `TagSpecifications` with `ResourceType: transit-gateway-attachment`).

## Root cause

`moto/ec2/responses/transit_gateway_attachments.py` read the parsed tag specification with the wrong resource type key:

```python
tags = self._parse_tag_specification().get("transit-gateway-route-table", {})
```

`_parse_tag_specification()` returns a dict keyed by `ResourceType`, so with the key copy-pasted from the route table handler the lookup always yielded `{}`. The correct type is `transit-gateway-attachment` (see `EC2_RESOURCE_TO_PREFIX` in `moto/ec2/utils.py`).

## Changes

- Use `transit-gateway-attachment` as the lookup key. One-line change, no other handlers touched.
- Add `test_create_transit_gateway_vpc_attachment_with_tags` (`@pytest.mark.aws_verified` + `ec2_aws_verified(create_vpc=True, create_subnet=True, create_transit_gateway=True)`). It asserts both create-time tags are present in the create response, in `DescribeTransitGatewayVpcAttachments`, and in `DescribeTransitGatewayAttachments`, and that a later `CreateTags` merges with them. Without the fix it fails with `KeyError: 'Tags'`.

## Testing

- `pytest tests/test_ec2/test_transit_gateway.py`: 37 passed (mocked).
- Against real AWS (`MOTO_TEST_ALLOW_AWS_REQUEST=true`, us-east-1): the new test passed in 5m14s; all resources were cleaned up by the helper.
- LocalStack Pro (host mode with this moto on `PYTHONPATH`): the original repro (`aws ec2 create-transit-gateway-vpc-attachment --tag-specifications ...` followed by `describe-transit-gateway-vpc-attachments`) now returns the create-time tags alongside the `CreateTags` one, and the Terraform config no longer shows drift on the attachment's `tags`.

## Not in scope

`DescribeTransitGatewayVpcAttachments` and `DescribeTransitGatewayAttachments` still ignore `tag:` filters (their `attr_pairs` have no tag handling and `describe_tag_filter` is only applied for peering attachments). Pre-existing and separate from this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrkEvTCFkudp83ifsALDe9
